### PR TITLE
Fast: fix integer size inconsistencies in i8

### DIFF
--- a/Fast/Fast/Fast/FILTER/filtrage_5.for
+++ b/Fast/Fast/Fast/FILTER/filtrage_5.for
@@ -45,7 +45,7 @@ C Var loc
       REAL_E fili, filj, filk
 
 C    adresse point courant pour tableau de la taille d'un domaine
-       integer*4 inddm, i_1,j_1,k_1
+       INTEGER_E inddm, i_1,j_1,k_1
 
        inddm(i_1,j_1,k_1) = 1
      &     + (i_1+param_int(NIJK+3)-1)

--- a/Fast/Fast/Fast/FILTER/move_to_temp.for
+++ b/Fast/Fast/Fast/FILTER/move_to_temp.for
@@ -41,7 +41,7 @@ C Var loc
       INTEGER_E ng, nx, ny, nz, ot
 
 C    adresse point courant pour tableau de la taille d'un domaine
-       integer*4 inddm, i_1,j_1,k_1
+       INTEGER_E inddm, i_1,j_1,k_1
 
        inddm(i_1,j_1,k_1) = 1
      &     + (i_1+param_int(NIJK+3)-1)

--- a/Fast/Fast/Fast/formule.h
+++ b/Fast/Fast/Fast/formule.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &                   + (i_1+nijk(4)-1)

--- a/Fast/Fast/Fast/formule_mtr.h
+++ b/Fast/Fast/Fast/formule_mtr.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &                   + (i_3+nijk_mtr(4)-1)*nijk_mtr(1)

--- a/Fast/Fast/Fast/formule_mtr_param.h
+++ b/Fast/Fast/Fast/formule_mtr_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &            + (i_3+param_int(NIJK_MTR+3)-1)*param_int(NIJK_MTR)

--- a/Fast/Fast/Fast/formule_param.h
+++ b/Fast/Fast/Fast/formule_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &     + (i_1+param_int(NIJK+3)-1)

--- a/Fast/Fast/Fast/formule_ssor_param.h
+++ b/Fast/Fast/Fast/formule_ssor_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 indssor, i_5,j_5,k_5,ssor_i,ssor_j
+      INTEGER_E indssor, i_5,j_5,k_5,ssor_i,ssor_j
 
       indssor(i_5,j_5,k_5) = 1
      &      + (i_5-ind_loop_sdm(1)+param_int(NIJK+3))

--- a/Fast/Fast/Fast/formule_vent_param.h
+++ b/Fast/Fast/Fast/formule_vent_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau vitesse entrainement
-      integer*4 indven, i_4,j_4,k_4
+      INTEGER_E indven, i_4,j_4,k_4
 
       indven(i_4,j_4,k_4) =  1
      &           + (i_4+param_int(NIJK_VENT+3)-1)*param_int(NIJK_VENT)

--- a/Fast/Fast/Fast/formule_xyz.h
+++ b/Fast/Fast/Fast/formule_xyz.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) =  1
      &                   + (i_2+nijk_xyz(4)-1)

--- a/Fast/Fast/Fast/formule_xyz_param.h
+++ b/Fast/Fast/Fast/formule_xyz_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) = 1  
      &     + (i_2+param_int(NIJK_XYZ+3)-1)

--- a/Fast/FastC/FastC/formule.h
+++ b/Fast/FastC/FastC/formule.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &                   + (i_1+nijk(4)-1)

--- a/Fast/FastC/FastC/formule_mtr.h
+++ b/Fast/FastC/FastC/formule_mtr.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &                   + (i_3+nijk_mtr(4)-1)*nijk_mtr(1)

--- a/Fast/FastC/FastC/formule_mtr_param.h
+++ b/Fast/FastC/FastC/formule_mtr_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &      + (i_3+param_int(NIJK_MTR+3)-1)*param_int(NIJK_MTR)

--- a/Fast/FastC/FastC/formule_param.h
+++ b/Fast/FastC/FastC/formule_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &     + (i_1+param_int(NIJK+3)-1)

--- a/Fast/FastC/FastC/formule_ssor_param.h
+++ b/Fast/FastC/FastC/formule_ssor_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 indssor, i_5,j_5,k_5,ssor_i,ssor_j
+      INTEGER_E indssor, i_5,j_5,k_5,ssor_i,ssor_j
 
       indssor(i_5,j_5,k_5) = 1
      &      + (i_5-ind_loop_sdm(1)+param_int(NIJK+3))

--- a/Fast/FastC/FastC/formule_vent_param.h
+++ b/Fast/FastC/FastC/formule_vent_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau vitesse entrainement
-      integer*4 indven, i_4,j_4,k_4
+      INTEGER_E indven, i_4,j_4,k_4
 
       indven(i_4,j_4,k_4) =  1
      &           + (i_4+param_int(NIJK_VENT+3)-1)*param_int(NIJK_VENT)

--- a/Fast/FastC/FastC/formule_xyz.h
+++ b/Fast/FastC/FastC/formule_xyz.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) =  1
      &                   + (i_2+nijk_xyz(4)-1)

--- a/Fast/FastC/FastC/formule_xyz_param.h
+++ b/Fast/FastC/FastC/formule_xyz_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) = 1  
      &     + (i_2+param_int(NIJK_XYZ+3)-1)

--- a/Fast/FastS/FastS/ADJOINT/AUSM/2d/dpJ_dpW_fluausm_euler_o3_2d.for
+++ b/Fast/FastS/FastS/ADJOINT/AUSM/2d/dpJ_dpW_fluausm_euler_o3_2d.for
@@ -68,8 +68,9 @@
 !# 44 "build/x86_r8/FastS/Compute/AUSM/2d/eff_fluausm_euler_o3_2d.for" 2
 
 
-      INTEGER*4 ndom, ithread, ind_loop(6), param_int(0:*), 
+      INTEGER*4 ndom, ithread, param_int(0:*), 
      & param_int_eff(0:*), iter
+      INTEGER_E ind_loop(6)
 
       REAL*8   xmut( param_int(41) )
       REAL*8   rop( param_int(41) * param_int(36) )
@@ -94,7 +95,7 @@
 
 
 !C Var loc
-      INTEGER*4 inc,incmax,l,lt,i,j,k,incmax2,nm,nm2,np,                  
+      INTEGER_E inc,incmax,l,lt,i,j,k,incmax2,nm,nm2,np,                  
      & l0,lt0,inci,incj,inck,ci,cj,lij,ltij,inci_mtr, incj_mtr,     
      & inck_mtr,icorr,jcorr,ls,v1,v2,v3,v4,v5,v6,wig_i,wig_j,wig_k, 
      & lfij,lxij,lf,lx,inc_x1,inc_x2,inc_x3,vslp,lvol,lvor,ir,il,   
@@ -238,7 +239,7 @@
 c -----------------*------------------*-------------------*-----------------*
 
 !C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &     + (i_1+param_int(0+3)-1) 
@@ -247,7 +248,7 @@ c -----------------*------------------*-------------------*-----------------*
 
 
 !C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) = 1  
      &     + (i_2+param_int(10+3)-1)  
@@ -257,7 +258,7 @@ c -----------------*------------------*-------------------*-----------------*
 
 
 !C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &                    + (i_3+param_int(5+3)-1)*param_int(5)

--- a/Fast/FastS/FastS/ADJOINT/AUSM/2d/fluausm_euler_o3_2d_b.for
+++ b/Fast/FastS/FastS/ADJOINT/AUSM/2d/fluausm_euler_o3_2d_b.for
@@ -148,10 +148,10 @@ C!    VARIABLES LOCALES POUR LE CALCUL DE dpP_dpW **************************
 c*************************************************************************
 
 CC    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C
 CC    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/BC/bvbs_extrapolate_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_extrapolate_d.for
@@ -61,7 +61,7 @@ C Var local
       REAL*8 c1, vmax
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
       INTRINSIC MAX
       REAL*8 max1
       REAL*8 max1d

--- a/Fast/FastS/FastS/BC/bvbs_farfield_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_farfield_d.for
@@ -83,11 +83,11 @@ C Var local
      +       rwid, etid, rid, roinvd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_inflow_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_inflow_d.for
@@ -84,11 +84,11 @@ C Var local
      +       , rvid, rwid, etid, rid, roinvd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_inflow_fich_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_inflow_fich_d.for
@@ -92,11 +92,11 @@ C Var local
      +       , rvid, rwid, etid, rid, roinvd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_inflow_newton_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_inflow_newton_d.for
@@ -105,11 +105,11 @@ C...  Tableaux de travail locaux
       LOGICAL nan
       INTEGER*4 indbci, ithread
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_inflow_supersonic_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_inflow_supersonic_d.for
@@ -71,7 +71,7 @@ C Var local
       REAL*8 ro, u, v, w, t, nut, c0, c1, c2, c3
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
       INTRINSIC ABS
       REAL*8 abs0
       REAL*8 abs1

--- a/Fast/FastS/FastS/BC/bvbs_outflow_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_outflow_d.for
@@ -83,11 +83,11 @@ C Var local
      +       rwintd, etintd, roid, ruid, rvid, rwid, etid, rid, roinvd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_outpres_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_outpres_d.for
@@ -96,11 +96,11 @@ C
 C...  Tableau de travail local
       INTEGER*4 indbci
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/BC/bvbs_periodique_azimuthal_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_periodique_azimuthal_d.for
@@ -70,7 +70,7 @@ C Var local
       REAL*8, DIMENSION(3, 3) :: rot
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
       INTRINSIC ACOS
       INTRINSIC COS
       INTRINSIC SIN

--- a/Fast/FastS/FastS/BC/bvbs_periodique_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_periodique_d.for
@@ -62,7 +62,7 @@ C Var local
       REAL*8 c1
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C
       IF (lrhs .EQ. 1) THEN
         c1 = 0.

--- a/Fast/FastS/FastS/BC/bvbs_wall_inviscid_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_wall_inviscid_d.for
@@ -68,11 +68,11 @@ C Var local
       REAL*8 ud, vd, wd, utd, vtd, wtd, uad, vad, wad, qnd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/BC/bvbs_wall_viscous_adia_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_wall_viscous_adia_d.for
@@ -68,9 +68,9 @@ C Var local
       REAL*8 ud, vd, wd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       EXTERNAL SHAPE_TAB_MTR
 C
 C

--- a/Fast/FastS/FastS/BC/bvbs_wall_viscous_transition_d.for
+++ b/Fast/FastS/FastS/BC/bvbs_wall_viscous_transition_d.for
@@ -77,13 +77,13 @@ C
       REAL*8 ud, vd, wd
 C
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      INTEGER*4 indcg, i_2, j_2, k_2
+      INTEGER_E indcg, i_2, j_2, k_2
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ATAN
       INTRINSIC SQRT
       INTRINSIC ABS

--- a/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_SA_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_SA_o3_2d_d.for
@@ -118,9 +118,9 @@ C
      +       xktvold, xmulamd, xmuturd, xmutotd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_euler_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_euler_o3_2d_d.for
@@ -115,9 +115,9 @@ C
      +       , p1d, p2d, sond, cd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_lamin_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/AUSM/2d/fluausm_lamin_o3_2d_d.for
@@ -117,9 +117,9 @@ C
      +       gradt_nxd, gradt_nyd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/DTLOC/conservativite32.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/conservativite32.for
@@ -34,7 +34,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk1
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
 

--- a/Fast/FastS/FastS/Compute/DTLOC/constantinescu.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/constantinescu.for
@@ -31,7 +31,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk1
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
 

--- a/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local.for
@@ -31,7 +31,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,posbis
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
 

--- a/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local2.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local2.for
@@ -34,7 +34,7 @@ c***********************************************************************
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
      &,nistk_
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,cycl
       REAL_E c1,roe,cv,cvinv,roe1,roe2
       REAL_E coeff1, coeff2

--- a/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local3.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local3.for
@@ -34,7 +34,7 @@ c***********************************************************************
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
      &,nistk_
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,cycl
       REAL_E c1,roe,cv,cvinv,roe1,roe2
       REAL_E coeff1, coeff2

--- a/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local4.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local4.for
@@ -31,7 +31,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,posbis
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
 

--- a/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local4para.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interp_rk3local4para.for
@@ -32,7 +32,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,posbis
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
       REAL_E roinv,u,v,w,dtl

--- a/Fast/FastS/FastS/Compute/DTLOC/interprk3local.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interprk3local.for
@@ -31,7 +31,7 @@ c***********************************************************************
  
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,posbis
       REAL_E c1,roe,cv,cvinv,ro_old,u_old,v_old,w_old,t_old,roe_old
 

--- a/Fast/FastS/FastS/Compute/DTLOC/interprk3local2.for
+++ b/Fast/FastS/FastS/Compute/DTLOC/interprk3local2.for
@@ -32,7 +32,7 @@ c***********************************************************************
 C Var local
       INTEGER_E l,ijkm,im,jm,km,ldjr,i,j,k,ne,lij,neq,n,nistk,lstk,ind,z
      &,nistk_
-      integer*4 inddm2,i_2,j_2,k_2
+      INTEGER_E inddm2,i_2,j_2,k_2
       INTEGER_E nistk2,nistk3,l2,lstk2,cycl
       REAL_E c1,roe,cv,cvinv,roe1,roe2
       REAL_E coeff1, coeff2

--- a/Fast/FastS/FastS/Compute/Linear_solver/bflwall_d.for
+++ b/Fast/FastS/FastS/Compute/Linear_solver/bflwall_d.for
@@ -36,11 +36,11 @@ C
      +       flu5, flu6, tcx, tcy, tcz
       REAL*8 pd, rd, ud, vd, wd, u_intd, flu2d, flu3d, flu4d, flu5d
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC MOD
       EXTERNAL SHAPE_TAB_MTR
 C

--- a/Fast/FastS/FastS/Compute/Linear_solver/core3as2_kry_d.for
+++ b/Fast/FastS/FastS/Compute/Linear_solver/core3as2_kry_d.for
@@ -17,7 +17,7 @@ C
       INTEGER*4 l, i, j, k, lij
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C
       IF (param_int(36) .EQ. 6) THEN
         DO k=ind_loop(5),ind_loop(6)

--- a/Fast/FastS/FastS/Compute/Linear_solver/corr_fluroe_euler_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/Linear_solver/corr_fluroe_euler_o3_2d_d.for
@@ -66,11 +66,11 @@ C
      +       , dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/Linear_solver/fluroe_euler_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/Linear_solver/fluroe_euler_o3_2d_d.for
@@ -78,9 +78,9 @@ C
      +       dud, dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       REAL*8 abs0
       REAL*8 abs0d
       REAL*8 abs1

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_SA_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_SA_minmod_2d_d.for
@@ -105,11 +105,11 @@ C
      +       roffd, dud, dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_SA_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_SA_o3_2d_d.for
@@ -103,11 +103,11 @@ C
      +       , qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_euler_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_euler_minmod_2d_d.for
@@ -105,11 +105,11 @@ C
      +       , qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_euler_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_euler_o3_2d_d.for
@@ -102,11 +102,11 @@ C
      +       , dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_lamin_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_lamin_minmod_2d_d.for
@@ -105,11 +105,11 @@ C
      +       , qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_lamin_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/corr_fluroe_lamin_o3_2d_d.for
@@ -102,11 +102,11 @@ C
      +       , dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_SA_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_SA_minmod_2d_d.for
@@ -121,9 +121,9 @@ C
      +       xktvold, xmulamd, xmuturd, xmutotd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_SA_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_SA_o3_2d_d.for
@@ -117,9 +117,9 @@ C
      +       , qd, r_1d, xktvold, xmulamd, xmuturd, xmutotd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_euler_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_euler_minmod_2d_d.for
@@ -117,9 +117,9 @@ C
      +       , qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_euler_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_euler_o3_2d_d.for
@@ -114,9 +114,9 @@ C
      +       dud, dvd, dpd, dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_lamin_minmod_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_lamin_minmod_2d_d.for
@@ -119,9 +119,9 @@ C
      +       , hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/2d/fluroe_lamin_o3_2d_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/2d/fluroe_lamin_o3_2d_d.for
@@ -116,9 +116,9 @@ C
      +       dqnd, qnd, rd, vd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_SA_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_SA_minmod_3dfull_d.for
@@ -107,11 +107,11 @@ C
      +       , vd, wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_SA_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_SA_o3_3dfull_d.for
@@ -105,11 +105,11 @@ C
      +       , dqnd, qnd, rd, vd, wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_euler_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_euler_minmod_3dfull_d.for
@@ -106,11 +106,11 @@ C
      +       , dvd, dwd, dpd, dqnd, qnd, rd, vd, wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_euler_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_euler_o3_3dfull_d.for
@@ -104,11 +104,11 @@ C
      +       hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_lamin_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_lamin_minmod_3dfull_d.for
@@ -106,11 +106,11 @@ C
      +       , dvd, dwd, dpd, dqnd, qnd, rd, vd, wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_lamin_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/corr_fluroe_lamin_o3_3dfull_d.for
@@ -104,11 +104,11 @@ C
      +       hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse interface pour tableau vitesse entrainement
-      INTEGER*4 indven, i_4, j_4, k_4
+      INTEGER_E indven, i_4, j_4, k_4
       INTRINSIC ABS
       INTRINSIC MOD
       INTRINSIC SQRT

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_SA_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_SA_minmod_3dfull_d.for
@@ -121,9 +121,9 @@ C
      +       , vd, wd, hd, qd, r_1d, xktvold, xmulamd, xmuturd, xmutotd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_SA_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_SA_o3_3dfull_d.for
@@ -119,9 +119,9 @@ C
      +       , xmuturd, xmutotd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_euler_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_euler_minmod_3dfull_d.for
@@ -117,9 +117,9 @@ C
      +       dud, dvd, dwd, dpd, dqnd, qnd, rd, vd, wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_euler_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_euler_o3_3dfull_d.for
@@ -114,9 +114,9 @@ C
      +       wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_lamin_minmod_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_lamin_minmod_3dfull_d.for
@@ -121,9 +121,9 @@ C
      +       r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_lamin_o3_3dfull_d.for
+++ b/Fast/FastS/FastS/Compute/ROE/3dfull/fluroe_lamin_o3_3dfull_d.for
@@ -117,9 +117,9 @@ C
      +       , wd, hd, qd, r_1d
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC ABS
       INTRINSIC SQRT
       INTRINSIC MAX

--- a/Fast/FastS/FastS/Compute/SA/spsource_SA_comp_d.for
+++ b/Fast/FastS/FastS/Compute/SA/spsource_SA_comp_d.for
@@ -94,9 +94,9 @@ C
      +       dudzd, dvdxd, dvdyd, dvdzd, dwdxd, dwdyd, dwdzd, ccd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC SQRT
       INTRINSIC MAX
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/SA/spsource_SA_d.for
+++ b/Fast/FastS/FastS/Compute/SA/spsource_SA_d.for
@@ -92,9 +92,9 @@ C
      +       dudzd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC SQRT
       INTRINSIC MAX
       INTRINSIC MIN

--- a/Fast/FastS/FastS/Compute/SA/spsource_SA_diff_d.for
+++ b/Fast/FastS/FastS/Compute/SA/spsource_SA_diff_d.for
@@ -92,9 +92,9 @@ C
      +       dudzd
 C
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
       INTRINSIC SQRT
       INTRINSIC ABS
       INTRINSIC EXP

--- a/Fast/FastS/FastS/Compute/SA/vispalart_d.for
+++ b/Fast/FastS/FastS/Compute/SA/vispalart_d.for
@@ -68,9 +68,9 @@ C
       REAL*8 amulamd, anulamd, fvv1d, anutildd, amutd, xmuprovd, chid
 C
 C    adresse interface pour tableau metric
-      INTEGER*4 indmtr, i_3, j_3, k_3
+      INTEGER_E indmtr, i_3, j_3, k_3
 C    adresse point courant pour tableau de la taille d'un domaine 
-      INTEGER*4 inddm, i_1, j_1, k_1
+      INTEGER_E inddm, i_1, j_1, k_1
       INTRINSIC SQRT
       INTRINSIC MAX
       INTRINSIC MIN

--- a/Fast/FastS/FastS/formule.h
+++ b/Fast/FastS/FastS/formule.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &                   + (i_1+nijk(4)-1)

--- a/Fast/FastS/FastS/formule_mtr.h
+++ b/Fast/FastS/FastS/formule_mtr.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &                   + (i_3+nijk_mtr(4)-1)*nijk_mtr(1)

--- a/Fast/FastS/FastS/formule_mtr_param.h
+++ b/Fast/FastS/FastS/formule_mtr_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau metric
-      integer*4 indmtr, i_3,j_3,k_3
+      INTEGER_E indmtr, i_3,j_3,k_3
 
       indmtr(i_3,j_3,k_3) =  1
      &            + (i_3+param_int(NIJK_MTR+3)-1)*param_int(NIJK_MTR)

--- a/Fast/FastS/FastS/formule_param.h
+++ b/Fast/FastS/FastS/formule_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 inddm, i_1,j_1,k_1
+      INTEGER_E inddm, i_1,j_1,k_1
 
       inddm(i_1,j_1,k_1) = 1  
      &     + (i_1+param_int(NIJK+3)-1)

--- a/Fast/FastS/FastS/formule_ssor_param.h
+++ b/Fast/FastS/FastS/formule_ssor_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau de la taille d'un domaine 
-      integer*4 indssor, i_5,j_5,k_5,ssor_i,ssor_j
+      INTEGER_E indssor, i_5,j_5,k_5,ssor_i,ssor_j
 
       indssor(i_5,j_5,k_5) = 1
      &      + (i_5-ind_loop_sdm(1)+param_int(NIJK+3))

--- a/Fast/FastS/FastS/formule_vent_param.h
+++ b/Fast/FastS/FastS/formule_vent_param.h
@@ -1,5 +1,5 @@
 C    adresse interface pour tableau vitesse entrainement
-      integer*4 indven, i_4,j_4,k_4
+      INTEGER_E indven, i_4,j_4,k_4
 
       indven(i_4,j_4,k_4) =  1
      &           + (i_4+param_int(NIJK_VENT+3)-1)*param_int(NIJK_VENT)

--- a/Fast/FastS/FastS/formule_xyz.h
+++ b/Fast/FastS/FastS/formule_xyz.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) =  1
      &                   + (i_2+nijk_xyz(4)-1)

--- a/Fast/FastS/FastS/formule_xyz_param.h
+++ b/Fast/FastS/FastS/formule_xyz_param.h
@@ -1,5 +1,5 @@
 C    adresse point courant pour tableau x ou de la taille d'un domaine 
-      integer*4 indcg, i_2,j_2,k_2
+      INTEGER_E indcg, i_2,j_2,k_2
 
       indcg(i_2,j_2,k_2) = 1  
      &     + (i_2+param_int(NIJK_XYZ+3)-1)


### PR DESCRIPTION
Errors detected with gcc 12.1.0