### PR TITLE
Bug fix in FastS lhs: infinite pending if LBM zone

### DIFF
--- a/Fast/FastS/FastS/Compute/lhs.cpp
+++ b/Fast/FastS/FastS/Compute/lhs.cpp
@@ -73,13 +73,13 @@ if( kimpli == 1  && param_int[0][LU_MATCH]==1 && param_int_tc != NULL)
 
          if(lssiter_verif ==1 )
           {
+            if (param_int[nd][ITYPZONE] != 4 and param_int[nd][IFLOW] != 4) // on skippe les eventuelles zone non structurees ou LBM
+            {
 #include   "FastS/Compute/verrou_residus.h"
 //            if( ntask==0 )
 //             {
 //#pragma omp barrier
 //             }
-            if (param_int[nd][ITYPZONE] != 4 and param_int[nd][IFLOW] != 4)  //on skippe les eventuelles zone non structurees ou LBM
-             {
                E_Int* ipt_topo_omp; E_Int* ipt_ind_dm_thread;
 
                ithread_loc           = ipt_omp[ pttask + 2 + ithread -1 ] +1 ;
@@ -88,7 +88,7 @@ if( kimpli == 1  && param_int[0][LU_MATCH]==1 && param_int_tc != NULL)
 
               //sortie de la carte residu du Newton
 #include      "FastS/Compute/residus_navier.h"
-             }// test lbm/unstructured
+            } // test lbm/unstructured
           }// test residu
 
         }// loop task residu


### PR DESCRIPTION
Fixes the problem that caused the test case `vortexWissocqHRR_t1.py` to timeout in the valid database of the Fast module. 

In fact, a lock was not modified if there was a LBM zone, causing an infinite wait. The problem has now been corrected and the test case in question is no longer in timeout.