### PR TITLE
[LBM] Fast/FastC: modif of switchPointersLBM and adding parameters and functions for LBM computations

### DIFF
--- a/Fast/Fast/Fast/PyTree.py
+++ b/Fast/Fast/Fast/PyTree.py
@@ -76,6 +76,13 @@ def warmup(t, tc=None, graph=None, infos_ale=None, Adjoint=False, tmy=None, list
     # Reordone les zones pour garantir meme ordre entre t et tc
     FastC._reorder(t, tc)
 
+    # Si version avec FASTLBM 
+    # Ajout du pas de temps, du temps de relaxation et des niveaux en temps
+    # Necessaire avant _buildOwnData puisque stockes dans param_int/param_real
+    if FASTLBM:
+        FastLBM._setTimeStepAndRelaxTime(t,verbose)
+        FastLBM._setTimeLevels(t, verbose)
+
     # Construction param_int et param_real des zones
     FastC._buildOwnData(t, Padding)
 
@@ -633,7 +640,7 @@ def _compute(t, metrics, nitrun, tc=None, graph=None, layer="c", NIT=1):
 
     if FASTLBM:
         if  NIT%2 != 0:
-            FastC.switchPointersLBM__(zones_lbm, FastLBM.NQ, dtloc)
+            FastC.switchPointersLBM__(zones_lbm, dtloc)
 
     maxlevel   = dtloc[9]
     nitCyclLBM = 2**(maxlevel-1)

--- a/Fast/Fast/Fast/PyTree.py
+++ b/Fast/Fast/Fast/PyTree.py
@@ -76,7 +76,7 @@ def warmup(t, tc=None, graph=None, infos_ale=None, Adjoint=False, tmy=None, list
     # Reordone les zones pour garantir meme ordre entre t et tc
     FastC._reorder(t, tc)
 
-    # Si version avec FASTLBM 
+    # Si version avec FASTLBM
     # Ajout du pas de temps, du temps de relaxation et des niveaux en temps
     # Necessaire avant _buildOwnData puisque stockes dans param_int/param_real
     if FASTLBM:

--- a/Fast/Fast/test/vortexWissocqHRR_t1.py
+++ b/Fast/Fast/test/vortexWissocqHRR_t1.py
@@ -6,16 +6,11 @@ import Generator.PyTree as G
 import Converter.PyTree as C
 import Converter.Internal as Internal
 import FastC.PyTree as FastC
-import FastASLBM.PyTree as FastLBM
 import Fast.PyTree as Fast
-#import FastLBM.PyTree as FastLBM
 import Connector.PyTree as X
-import Transform.PyTree as T
-import Post.PyTree as P
-import KCore.test as test
 import Apps.Fast.LBM as App
+import KCore.test as test
 
-import math
 import numpy
 import time
 
@@ -24,23 +19,16 @@ myApp = App.LBM(format='single')
 #==========================================
 # Generation du maillage
 #==========================================
-x_min = 0.0
-L = 1.
+x_min = 0.0; L = 1.
 Nx=101; Ny = Nx; Nz = 11
-#Nx=41; Ny = Nx; Nz = 3
-n = Nx-1
-dx = L/n
-print(dx)
+n = Nx-1; dx = L/n; print('Grid spacing=',dx)
 z_min = -4*dx
+
 a1 = G.cart((x_min,x_min,z_min), (dx,dx,dx), (Nx,Ny,Nz))
 t = C.newPyTree(['Base',a1])
-
 t,tc = myApp.prepare(t, t_out=None, tc_out=None, NP=0, translation=[(Nx-1)*dx, (Ny-1)*dx,(Nz-1)*dx],NG=2)
 
-test.testT(t,1)
-test.testT(tc,2)
-'''
-'''
+test.testT(t,1); test.testT(tc,2)
 
 #==========================================
 # Initialisation du cas-test
@@ -52,22 +40,17 @@ Rgp = 287.053
 Tref = Pref/(Rhoref*Rgp)
 c0 = numpy.zeros(1,dtype=numpy.float64)
 c0[0] = numpy.sqrt(gamma*Rgp*Tref)
-
 mach = 0.1
 u0 = mach*c0[0]
-v_adim=1./(numpy.sqrt(3.,dtype=numpy.float64)*c0)
-v_adiminv = numpy.sqrt(3.,dtype=numpy.float64)*c0
+visco_nu = 0.
 
-# PARAMETRES DU VORTEX
+# Parametres du vortex
 R0 = L/10.
-epsilon = 0.07*c0[0] #0.5*c0[0]
-eps_2 = epsilon**2
-dt = dx / (3. ** 0.5 * c0[0])
-R0_2Inv= 1./(R0*R0)
-R0_3Inv= 1./(R0*R0*R0)
+epsilon = 0.07*c0[0]; eps_2 = epsilon**2
+R0_2Inv= 1./(R0*R0); R0_3Inv= 1./(R0*R0*R0)
 x_0 = 0.5; y_0 = 0.5
 
-# INITIALISATION
+# Initialisation : champs macros
 C._initVars(t,"{centers:r2}=({centers:CoordinateX}-%20.16g)**2+({centers:CoordinateY}-%20.16g)**2"%(x_0,y_0))
 C._initVars(t,'{centers:Density}= %20.16g*exp(-%20.16g/(2.*%20.16g**2)*exp(-{centers:r2}*%20.16g))'%(Rhoref,eps_2,c0[0],R0_2Inv))
 C._initVars(t,'{centers:VelocityX}=%20.16g-%20.16g*(({centers:CoordinateY}-%20.16g)*%20.16g)*exp(-0.5*{centers:r2}*%20.16g)'%(u0,epsilon,y_0,1./R0,R0_2Inv))
@@ -75,97 +58,54 @@ C._initVars(t,'{centers:VelocityY}=%20.16g+%20.16g*(({centers:CoordinateX}-%20.1
 C._initVars(t,'{centers:VelocityZ}=0.')
 C._initVars(t,'{centers:Temperature}=%20.16g'%(Tref))
 
+# Initialisation : gradients
 C._initVars(t,'{centers:Sxx} = %20.16g*({centers:CoordinateY}-%20.16g)*%20.16g*({centers:CoordinateX}-%20.16g)*%20.16g*exp(-0.5*{centers:r2}*%20.16g)'%(epsilon,y_0,1./R0,x_0,R0_2Inv,R0_2Inv))
 C._initVars(t,'{centers:Sxy} = 0.5*%20.16g*%20.16g*exp(-0.5*{centers:r2}*%20.16g)*(({centers:CoordinateY}-%20.16g)**2 - ({centers:CoordinateX}-%20.16g)**2)'%(epsilon,R0_3Inv,R0_2Inv,y_0,x_0))
 C._initVars(t,'{centers:Syy} = -%20.16g*({centers:CoordinateY}-%20.16g)*%20.16g*({centers:CoordinateX}-%20.16g)*%20.16g*exp(-0.5*{centers:r2}*%20.16g)'%(epsilon,y_0,R0_2Inv,x_0,1./R0,R0_2Inv))
 C._initVars(t,'{centers:Sxz} = 0.0')
 C._initVars(t,'{centers:Syz} = 0.0')
 C._initVars(t,'{centers:Szz} = 0.0')
-
-# ADIMENSIONNEMENT DE LA LBM
-C._initVars(t,'{centers:Density}={centers:Density}*%20.16g'%(1./Rhoref))
-C._initVars(t,'{centers:VelocityX}={centers:VelocityX}*%20.16g'%v_adim[0])
-C._initVars(t,'{centers:VelocityY}={centers:VelocityY}*%20.16g'%v_adim[0])
-C._initVars(t,'{centers:Sxx} = {centers:Sxx}*%20.16g'%dt)
-C._initVars(t,'{centers:Sxy} = {centers:Sxy}*%20.16g'%dt)
-C._initVars(t,'{centers:Syy} = {centers:Syy}*%20.16g'%dt)
-
 C._rmVars(t,['centers:r2'])
 
-C._addState(t, MInf=mach)
-C._addState(t, adim='dim3', UInf=mach*c0, PInf=101320., RoInf=1.1765, LInf=1.)
-VARSMACRO = ['Density','VelocityX','VelocityY','VelocityZ','Temperature','Sxx','Sxy','Sxz','Syy','Syz','Szz']
-for v in VARSMACRO: C._cpVars(t,'centers:'+v,tc,v)
-X._setInterpTransfers(t,tc,variables=VARSMACRO)
+C._addState(t, adim='dim3',UInf=u0,PInf=Pref,RoInf=Rhoref,LInf=L); C._addState(t, 'Mus', visco_nu)
 
 #==========================================
-# Preparation du calcul
+# Parametres de calcul
+#==========================================
+
+# Parametres globaux
+numb = {'temporal_scheme':'explicit', 'ss_iteration':20,'omp_mode':0}
+numz = {}
+# Utile pour debug
+# numz['cache_blocking_I']=1000000
+# numz['cache_blocking_J']=1000000
+# numz['cache_blocking_K']=1000000
+
+# Parametres propres a la LBM
+numz["LBM_velocity_set"] = "D3Q19"
+numz["LBM_coll_model"]   = "HRR"
+numz["LBM_hrr_sigma"]   = 0.98
+
+FastC._setNum2Zones(t, numz); FastC._setNum2Base(t, numb)
+
+#==========================================
+# Warmup
+#==========================================
+
+(t, tc, metrics)  = Fast.warmup(t, tc)
+
+#==========================================
+# Calcul
 #==========================================
 ncyc = 0.01
 nit = int(ncyc*n/(1./numpy.sqrt(3.,dtype=numpy.float64)*mach))
 print(nit)
 
-# Numerics
-numb = {'temporal_scheme':'explicit', 'ss_iteration':20,'omp_mode':0}
-numz = {'scheme':'ausmpred'}#,'io_thread':1}
-numz["time_step"]=dt # pour l instant taug=0.5 (pas de viscosite)
-
-# Helpful for debug
-# numz['cache_blocking_I']=1000000
-# numz['cache_blocking_J']=1000000
-# numz['cache_blocking_K']=1000000
-
-# LBM own parameters
-nu_d = (15.6e-6)/Rhoref
-numz["LBM_relax_time"]        = 0.5#+nu_d/(c0[0]*c0[0]*numz["time_step"])
-numz["LBM_coll_model"]   = "HRR"
-numz["LBM_hrr_sigma"]   = 0.98
-# numz["LBM_HLBM"] = 0
-# numz["LBM_dx"] = dx
-
-
-myApp.set(numb=numb); myApp.set(numz=numz)
-FastC._setNum2Zones(t, numz); FastC._setNum2Base(t, numb)
-
-t = C.node2Center(t, ['CoordinateX','CoordinateY'])
-
-
-#(t, tc, metrics)  = FastLBM.warmup(t, tc, flag_initprecise=1)
-(t, tc, metrics)  = Fast.warmup(t, tc)
-
-MESH = ['CoordinateX','CoordinateY']
-for z in Internal.getZones(t):
-    dim = Internal.getZoneDim(z)
-    Nx = dim[1]-1-4; Ny = dim[2]-1-4; Nz = dim[3]-1-4
-    GridCoordinates = numpy.zeros((Nx,Ny,2))
-    gridcoord = Internal.getNodeFromName(z,'FlowSolution#Centers')
-    for j,msh in enumerate(MESH):
-        c = Internal.getNodeFromName(gridcoord,msh)[1]
-        GridCoordinates[:,:,j] = c[2:-2,2:-2,0]
-
-#test.testT(t,3)
-#test.testT(tc,4)
-#import os; sys.exit()
-
-
-#==========================================
-# CALCUL
-#==========================================
-tab_min = numpy.zeros((nit,2))
-inst = 0.
 start_all = time.time()
 
 for it in range(0,nit+1):
-    #inst = inst + dt
     print("--------- iteration %d -------------"%it)
-    #start = time.time()
-    #FastLBM._compute(t, metrics, it, tc, layer='c')
-    #FastLBM._compute(t, metrics, it, tc, layer='Python')
-    #Fast._compute(t, metrics, it, tc, layer='Python')
-    Fast._compute(t, metrics, it, tc, layer='c')
-    #end = time.time()
-    #print('Temps d''execution :',end-start)
-    # FastLBM.display_cpu_efficiency(t)
+    Fast._compute(t, metrics, it, tc)
 
 end_all = time.time()
 print('')
@@ -175,19 +115,16 @@ print('')
 #==========================================
 # POST TRAITEMENT
 #==========================================
+
 Internal._rmNodesByName(t, '.Solver#Param')
 Internal._rmNodesByName(t, '.Solver#ownData')
+Internal._rmNodesByName(t, "*_P1")
 
-#
 VARSMACRO = ['Density','VelocityX','VelocityY','VelocityZ','Temperature','Sxx','Sxy','Sxz','Syy','Syz','Szz']
 for v in VARSMACRO: C._cpVars(t,'centers:'+v,tc,v)
 X._setInterpTransfers(t,tc,variables=VARSMACRO)
-#
 
 #Internal._rmGhostCells(t,t,2)
 #C.convertPyTree2File(t,"ASLBM.cgns")
 Internal._rmNodesByName(t, "*_P1")
 test.testT(t,5)
-
-
-#0.331663595885055

--- a/Fast/FastC/FastC/PyTree.py
+++ b/Fast/FastC/FastC/PyTree.py
@@ -2630,79 +2630,71 @@ def switchPointers3__(zones,nitmax):
 #==============================================================================
 # echange M1 <- current, current <- P1, P1 <- M1
 #==============================================================================
-def switchPointersLBM__(zones, neq_lbm, dtloc):
+def switchPointersLBM__(zones, dtloc):
 
     for z in zones:
         param_int = Internal.getNodeFromName2(z, 'Parameter_int')[1]  # noeud
+        
+        # Number of discrete velocities
+        NQ = param_int[VSHARE.NEQ_LBM]
+
+        # Local time stepping parameters
         level = param_int[VSHARE.LEVEL]
         maxlevel    = dtloc[ 9]
         it_cycl_lbm = dtloc[10]
         level_tg = dtloc[12 +it_cycl_lbm]
-
         max_it        = 2**( maxlevel-1)
-
         level_next_it =  maxlevel;
         if it_cycl_lbm != max_it -1 : level_next_it = dtloc[12 +it_cycl_lbm +1]
 
         #if level==1 or (level >=2 and level <= level_next_it) :
         if level <= level_next_it :
             #print("switch Pt", z[0])
-
             sol = Internal.getNodeFromName1(z, 'FlowSolution#Centers')
 
-            #cro = Internal.getNodeFromName1(sol, 'Density')
-            #cux = Internal.getNodeFromName1(sol, 'VelocityX')
-            #cuy = Internal.getNodeFromName1(sol, 'VelocityY')
-            #cuz = Internal.getNodeFromName1(sol, 'VelocityZ')
-            #cT  = Internal.getNodeFromName1(sol, 'Temperature')
+            # SWITCH POINTERS : MACROSCOPIC VARIABLES
+            cro = Internal.getNodeFromName1(sol, 'Density'    )
+            cux = Internal.getNodeFromName1(sol, 'VelocityX'  )
+            cuy = Internal.getNodeFromName1(sol, 'VelocityY'  )
+            cuz = Internal.getNodeFromName1(sol, 'VelocityZ'  )
+            cT  = Internal.getNodeFromName1(sol, 'Temperature')
 
-            #croP1 = Internal.getNodeFromName1(sol, 'Density_P1')
-            #cuxP1 = Internal.getNodeFromName1(sol, 'VelocityX_P1')
-            #cuyP1 = Internal.getNodeFromName1(sol, 'VelocityY_P1')
-            #cuzP1 = Internal.getNodeFromName1(sol, 'VelocityZ_P1')
-            #cTP1  = Internal.getNodeFromName1(sol, 'Temperature_P1')
-
-        #    C._cpVars(z, 'centers:Density'    , z, 'centers:Density_M1'    )
-        #    C._cpVars(z, 'centers:VelocityX'  , z, 'centers:VelocityX_M1'  )
-        #    C._cpVars(z, 'centers:VelocityY'  , z, 'centers:VelocityY_M1'  )
-        #    C._cpVars(z, 'centers:VelocityZ'  , z, 'centers:VelocityZ_M1'  )
-        #    C._cpVars(z, 'centers:Temperature', z, 'centers:Temperature_M1')
-            # sauvegarde M1
-            #ta = cro[1]; tb = cux[1]; tc = cuy[1]; td = cuz[1]; te = cT[1];
-            # M1 <- current
-            #cro[1] = croP1[1]; cux[1] = cuxP1[1]; cuy[1] = cuyP1[1]; cuz[1] = cuzP1[1]; cT[1] = cTP1[1];
-            # current <- P1
-            #croP1[1] = ta; cuxP1[1] = tb; cuyP1[1] = tc; cuzP1[1] = td; cTP1[1] = te;
-
-            #cxx = Internal.getNodeFromName1(sol, 'Sxx')
-            #cxy = Internal.getNodeFromName1(sol, 'Sxy')
-            #cxz = Internal.getNodeFromName1(sol, 'Sxz')
-            #cyy = Internal.getNodeFromName1(sol, 'Syy')
-            #cyz = Internal.getNodeFromName1(sol, 'Syz')
-            #czz = Internal.getNodeFromName1(sol, 'Szz')
-
-            #cxxP1 = Internal.getNodeFromName1(sol, 'Sxx_P1')
-            #cxyP1 = Internal.getNodeFromName1(sol, 'Sxy_P1')
-            #cxzP1 = Internal.getNodeFromName1(sol, 'Sxz_P1')
-            #cyyP1 = Internal.getNodeFromName1(sol, 'Syy_P1')
-            #cyzP1 = Internal.getNodeFromName1(sol, 'Syz_P1')
-            #czzP1 = Internal.getNodeFromName1(sol, 'Szz_P1')
-
-        #    C._cpVars(z, 'centers:Sxx'    , z, 'centers:sxx_M1')
-        #    C._cpVars(z, 'centers:Sxy'    , z, 'centers:Sxy_M1')
-        #    C._cpVars(z, 'centers:Sxz'    , z, 'centers:Sxz_M1')
-        #    C._cpVars(z, 'centers:Syy'    , z, 'centers:Syy_M1')
-        #    C._cpVars(z, 'centers:Syz'    , z, 'centers:Syz_M1')
-        #    C._cpVars(z, 'centers:Szz'    , z, 'centers:Szz_M1')
+            croP1 = Internal.getNodeFromName1(sol, 'Density_P1'    )
+            cuxP1 = Internal.getNodeFromName1(sol, 'VelocityX_P1'  )
+            cuyP1 = Internal.getNodeFromName1(sol, 'VelocityY_P1'  )
+            cuzP1 = Internal.getNodeFromName1(sol, 'VelocityZ_P1'  )
+            cTP1  = Internal.getNodeFromName1(sol, 'Temperature_P1')
 
             # sauvegarde M1
-            #ta = cxx[1]; tb = cxy[1]; tc = cxz[1]; td = cyy[1]; te = cyz[1];  tf = czz[1]
+            ta = cro[1]; tb = cux[1]; tc = cuy[1]; td = cuz[1]; te = cT[1];
             # M1 <- current
-            #cxx[1] = cxxP1[1]; cxy[1] = cxyP1[1]; cxz[1] = cxzP1[1]; cyy[1] = cyyP1[1]; cyz[1] = cyzP1[1];  czz[1] = czzP1[1];
+            cro[1] = croP1[1]; cux[1] = cuxP1[1]; cuy[1] = cuyP1[1]; cuz[1] = cuzP1[1]; cT[1] = cTP1[1];
             # current <- P1
-            #cxxP1[1] = ta; cxyP1[1] = tb; cxzP1[1] = tc; cyyP1[1] = td; cyzP1[1] = te;  czzP1[1] = tf;
+            croP1[1] = ta; cuxP1[1] = tb; cuyP1[1] = tc; cuzP1[1] = td; cTP1[1] = te;
 
-            for i in range(1,neq_lbm+1):
+            # SWITCH POINTERS : SHEAR STRESS TENSOR
+            cxx = Internal.getNodeFromName1(sol, 'Sxx')
+            cxy = Internal.getNodeFromName1(sol, 'Sxy')
+            cxz = Internal.getNodeFromName1(sol, 'Sxz')
+            cyy = Internal.getNodeFromName1(sol, 'Syy')
+            cyz = Internal.getNodeFromName1(sol, 'Syz')
+            czz = Internal.getNodeFromName1(sol, 'Szz')
+
+            cxxP1 = Internal.getNodeFromName1(sol, 'Sxx_P1')
+            cxyP1 = Internal.getNodeFromName1(sol, 'Sxy_P1')
+            cxzP1 = Internal.getNodeFromName1(sol, 'Sxz_P1')
+            cyyP1 = Internal.getNodeFromName1(sol, 'Syy_P1')
+            cyzP1 = Internal.getNodeFromName1(sol, 'Syz_P1')
+            czzP1 = Internal.getNodeFromName1(sol, 'Szz_P1')
+
+            # sauvegarde M1
+            ta = cxx[1]; tb = cxy[1]; tc = cxz[1]; td = cyy[1]; te = cyz[1];  tf = czz[1]
+            # M1 <- current
+            cxx[1] = cxxP1[1]; cxy[1] = cxyP1[1]; cxz[1] = cxzP1[1]; cyy[1] = cyyP1[1]; cyz[1] = cyzP1[1];  czz[1] = czzP1[1];
+            # current <- P1
+            cxxP1[1] = ta; cxyP1[1] = tb; cxzP1[1] = tc; cyyP1[1] = td; cyzP1[1] = te;  czzP1[1] = tf;
+
+            for i in range(1, NQ+1):
                 caM1 = Internal.getNodeFromName1(sol, 'Q'+str(i)+'_M1')
                 ca   = Internal.getNodeFromName1(sol, 'Q'+str(i))
 

--- a/Fast/FastC/FastC/PyTree.py
+++ b/Fast/FastC/FastC/PyTree.py
@@ -2634,7 +2634,7 @@ def switchPointersLBM__(zones, dtloc):
 
     for z in zones:
         param_int = Internal.getNodeFromName2(z, 'Parameter_int')[1]  # noeud
-        
+
         # Number of discrete velocities
         NQ = param_int[VSHARE.NEQ_LBM]
 


### PR DESCRIPTION
Changes to the Fast and FastC modules for LBM calculations.
There have been three main changes: 
- the switchPointersLBM function of FastC has been rewritten in a more generic fashion (NQ no longer passed as an argument), and takes into account the "_P1" time level
- Some calls to FastASLBM (if present) have been added to Fast in order to perform LB computations
- The test case vortexWissocqHRR_t1.py has been rewritten with updated FastASLBM functions.

Warning ! If FastASLBM is not updated accordingly, the test case `vortexWissocqHRR_t1.py` might fail since new functions were introduced.
