### PR TITLE
FastC: Combining loadTree and loadFile into one function

### DIFF
--- a/Fast/FastS/test/explicitLocalBodyFitted_t1.py
+++ b/Fast/FastS/test/explicitLocalBodyFitted_t1.py
@@ -15,16 +15,18 @@ import shutil
 test.TOLERANCE=1.e-10
 
 LOCAL = test.getLocal()
+tFileName = LOCAL + '/cgns_lts/t3DLTS.cgns'
+tcFileName = LOCAL + '/cgns_lts/tc3DLTS.cgns'
 
 ## BEGINNING OF COMPUTE
-if not os.path.isfile(LOCAL+'/cgns_lts/t3DLTS.cgns'):
+if not os.path.isfile(tFileName):
     if LOCAL != '.': shutil.copy("cgns_lts.tar.gz", LOCAL+'/cgns_lts.tar.gz')
     tar = tarfile.open(LOCAL+'/cgns_lts.tar.gz', "r:gz")
     tar.extractall(path=LOCAL)
     tar.close()
 
-t  = Fast.loadTree('cgns_lts/t3DLTS.cgns', directory=LOCAL)
-tc = Fast.loadTree('cgns_lts/tc3DLTS.cgns', directory=LOCAL)
+t  = Fast.loadTree(tFileName)
+tc = Fast.loadTree(tcFileName)
 
 NIT                        = 100     # number of iterations
 display_probe_freq         = 10      # iteration frequency to display modulo_verif

--- a/Fast/FastS/test/explicitLocalIbm_t1.py
+++ b/Fast/FastS/test/explicitLocalIbm_t1.py
@@ -10,15 +10,17 @@ import tarfile
 import shutil
 
 LOCAL = test.getLocal()
+tFileName = LOCAL + '/cgns_lts/t2DLTS_ibm.cgns'
+tcFileName = LOCAL + '/cgns_lts/tc2DLTS_ibm.cgns'
 
-if not os.path.isfile(LOCAL+'/cgns_lts/t2DLTS.cgns'):
+if not os.path.isfile(tFileName):
     if LOCAL != '.': shutil.copy("cgns_lts.tar.gz", LOCAL+'/cgns_lts.tar.gz')
     tar = tarfile.open(LOCAL+'/cgns_lts.tar.gz', "r:gz")
     tar.extractall(path=LOCAL)
     tar.close()
 
-t  = Fast.loadTree('cgns_lts/t2DLTS_ibm.cgns', directory=LOCAL)
-tc = Fast.loadTree('cgns_lts/tc2DLTS_ibm.cgns', directory=LOCAL)
+t  = Fast.loadTree(tFileName)
+tc = Fast.loadTree(tcFileName)
 
 NIT                        = 100   # number of iterations
 display_probe_freq         = 10    # iteration frequency to display modulo_verif


### PR DESCRIPTION
Combining `loadTree` and `loadFile` into one function: loadTree (loadFile will soon be deprecated, now an alias).

  - if rank in filename, add an underscore: `filename_rank.cgns`
  - if a pickled graph exist for filename parent_dir/f.cgns, set the path as follows: `parent_dir/f/graph.pk`
  - an exception is raised if a file is not found
  - add support for local dt

Note: `directory` is no longer an argument to `loadTree`