### PR TITLE
Fast: add verbose option for allocate_metric

### DIFF
--- a/Fast/Fast/Fast/PyTree.py
+++ b/Fast/Fast/Fast/PyTree.py
@@ -334,7 +334,7 @@ def allocate_metric(t, nghost, verbose=1):
             else:
                 metrics.append(FastS.fasts.allocate_metric(z, nssiter, verbose))
         #else: metrics.append(FastP.fastp.allocate_metric(z, nssiter, verbose))
-                
+
     if verbose == 0: # bilan only
         total = len(zones)
         if cpt[0] > 0: print("Info: typezones: 3D curvilinear, %2.2f%% (%d/%d)"%((cpt[0]/total*100.), cpt[0], total))

--- a/Fast/FastS/FastS/Metric/allocate_metric.cpp
+++ b/Fast/FastS/FastS/Metric/allocate_metric.cpp
@@ -33,8 +33,8 @@ using namespace K_FLD;
 //=============================================================================
 PyObject* K_FASTS::allocate_metric(PyObject* self, PyObject* args)
 {
-  PyObject *zone; E_Int nssiter;
-  if (!PYPARSETUPLE_(args, O_ I_, &zone, &nssiter)) return NULL; 
+  PyObject *zone; E_Int nssiter; E_Int verbose;
+  if (!PYPARSETUPLE_(args, O_ II_, &zone, &nssiter, &verbose)) return NULL; 
 
   vector<PyArrayObject*> hook;
   PyObject* metrics  = PyList_New(0); 
@@ -266,11 +266,13 @@ PyObject* K_FASTS::allocate_metric(PyObject* self, PyObject* args)
      else if (PyUnicode_Check(zname_py)) zname = (char*)PyUnicode_AsUTF8(zname_py);
 #endif
      else zname = NULL;
-     if      (typ_zone == 0) {printf("typezone: 3D curvilinear, %s (%d, %d, %d)\n", zname, ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1], ipt_param_int[ IJKV +2]);}
-     else if (typ_zone == 1) {printf("typezone: 3D, homogenous k direction with constant step, %s (%d, %d, %d)\n", zname,ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1],  ipt_param_int[ IJKV +2]);}
-     else if (typ_zone == 2) {printf("typezone: 3D cartesian with constant step, %s (%d, %d, %d)\n",  zname,ipt_param_int[ IJKV ],  ipt_param_int[ IJKV +1],  ipt_param_int[ IJKV +2]);}
-     else if (typ_zone == 3) {printf("typezone: 2D curvilinear, %s (%d, %d, %d)\n", zname, ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1], ipt_param_int[ IJKV +2]);}
-
+     if (verbose > 0)
+     {
+      if      (typ_zone == 0) {printf("typezone: 3D curvilinear, %s (%d, %d, %d)\n", zname, ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1], ipt_param_int[ IJKV +2]);}
+      else if (typ_zone == 1) {printf("typezone: 3D homogenous k direction with constant step, %s (%d, %d, %d)\n", zname,ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1],  ipt_param_int[ IJKV +2]);}
+      else if (typ_zone == 2) {printf("typezone: 3D Cartesian with constant step, %s (%d, %d, %d)\n",  zname,ipt_param_int[ IJKV ],  ipt_param_int[ IJKV +1],  ipt_param_int[ IJKV +2]);}
+      else if (typ_zone == 3) {printf("typezone: 2D curvilinear, %s (%d, %d, %d)\n", zname, ipt_param_int[ IJKV ], ipt_param_int[ IJKV +1], ipt_param_int[ IJKV +2]);}
+     }
      //
      //* Declare memoire pour metric: normales + volume)
      //

--- a/Fast/FastS/FastS/Mpi.py
+++ b/Fast/FastS/FastS/Mpi.py
@@ -797,7 +797,7 @@ def warmup(t, tc, graph=None, infos_ale=None, Adjoint=False, tmy=None, list_grap
 
     # alloue metric: tijk, ventijk, ssiter_loc
     # init         : ssiter_loc
-    metrics = allocate_metric(t)
+    metrics = allocate_metric(t, verbose)
 
     # Contruction BC_int et BC_real pour CL
     FastC._BCcompact(t)


### PR DESCRIPTION
Two levels of verbose for allocate_metric (like souszones_list) 
-> 1: print zonetype info for each zone
-> 0: print only global info at the end 

default is 1 (keeps current behavior)

Adding another level of verbose, where 2 is expert mode (actual mode 1), 1 prints only global info, and 0 prints nothing, seems unnecessary and overly complicated.