### PR TITLE
FastC: sort tc bases as t (and remove sortByName)

### DIFF
--- a/Fast/FastC/FastC/PyTree.py
+++ b/Fast/FastC/FastC/PyTree.py
@@ -143,8 +143,20 @@ def _reorder(t, tc=None):
 
     if tc is not None:
         #reordone les bases, sinon souci potentiel en MPi si ordre base != entre proc
-        Internal._sortByName(tc,recursive=False)
-        Internal._sortByName(t, recursive=False)
+        # Internal._sortByName(tc,recursive=False)
+        # Internal._sortByName(t, recursive=False)
+
+        #reordone les bases de tc, sinon souci potentiel transfert si ordre base != entre t et tc
+        Internal._copySort(t, tc, recursive=False)
+        # base_tcNew=[]
+        # for base in Internal.getBases(t):
+        #     base_tc = Internal.getNodeFromName(tc,base[0])
+        #     base_tcNew.append(base_tc)
+        # l = tc[2]
+        # orig = []
+        # for i in l:
+        #    if i[3] != 'CGNSBase_t': orig.append(i)
+        # tc[2] = orig+base_tcNew
 
         #reordone les zones de tc par taille decroissante dans chaque base pour optim openmp
         bases_tc = Internal.getNodesFromType1(tc, 'CGNSBase_t')
@@ -4329,7 +4341,7 @@ def tcStat_IBC(t,tc,vartTypeIBC=2,bcTypeIB=3):
 #==============================================================================
 def prepGraphs(t, exploc=0):
     #reorder base pour avoir procList consistant avec reorder du warmup. Sinon boom possible miseaplatdonnorTree
-    Internal._sortByName(t,recursive=False)
+    # Internal._sortByName(t,recursive=False)
 
     graphID   = Cmpi.computeGraph(t, type='ID'  , reduction=False, exploc=exploc)
     graphIBCD = Cmpi.computeGraph(t, type='IBCD', reduction=False, exploc=exploc)

--- a/Fast/FastS/test/cylindreChimerePT_t1.py
+++ b/Fast/FastS/test/cylindreChimerePT_t1.py
@@ -87,4 +87,13 @@ for it in range(nit):
 
 Internal._rmNodesByName(t, '.Solver#Param')
 Internal._rmNodesByName(t, '.Solver#ownData')
+
+####
+# The following lines are to avoid regression since the removal of sortByName in FastS warmup
+####
+Internal._sortByName(t, recursive=False)
+cgnslibver = Internal.getNodeByType(t, 'CGNSLibraryVersion_t')
+Internal._rmNodesByType(t, 'CGNSLibraryVersion_t')
+Internal.addChild(t, cgnslibver, 0)
+####
 test.testT(t, 1)

--- a/Fast/FastS/test/cylindreOctreePT_t1.py
+++ b/Fast/FastS/test/cylindreOctreePT_t1.py
@@ -110,4 +110,13 @@ Internal._rmNodesByName(t, '.Solver#Param')
 Internal._rmNodesByName(t, '.Solver#ownData')
 #C.convertPyTree2File(t, 'out.cgns')
 
+####
+# The following lines are to avoid regression since the removal of sortByName in FastS warmup
+####
+Internal._sortByName(t, recursive=False)
+cgnslibver = Internal.getNodeByType(t, 'CGNSLibraryVersion_t')
+Internal._rmNodesByType(t, 'CGNSLibraryVersion_t')
+Internal.addChild(t, cgnslibver, 0)
+####
+
 test.testT(t, 1)

--- a/Fast/FastS/test/diagCpu_t1.py
+++ b/Fast/FastS/test/diagCpu_t1.py
@@ -113,4 +113,14 @@ FastS.display_cpu_efficiency(t, mask_cpu=-0.05, mask_cell=0.008, FILEOUT=LOCAL+'
 Internal._rmNodesByName(t, '.Solver#Param')
 Internal._rmNodesByName(t, '.Solver#ownData')
 #C.convertPyTree2File(t, 'out.cgns')
+
+####
+# The following lines are to avoid regression since the removal of sortByName in FastS warmup
+####
+Internal._sortByName(t, recursive=False)
+cgnslibver = Internal.getNodeByType(t, 'CGNSLibraryVersion_t')
+Internal._rmNodesByType(t, 'CGNSLibraryVersion_t')
+Internal.addChild(t, cgnslibver, 0)
+####
+
 test.testT(t, 1)


### PR DESCRIPTION
Sorting is based on the Internal copySort function.
Several test cases are modified at the end to avoid regressions.

!! WARNING !! Cassiopee must be updated at the same time due to IBMO apps test cases