### PR TITLE
FastS: purge getFromNumy + shiftzone en int64

### DIFF
--- a/Fast/Fast/Fast/FILTER/filtering_.cpp
+++ b/Fast/Fast/Fast/FILTER/filtering_.cpp
@@ -104,7 +104,7 @@ PyObject* K_FAST::filtering_(PyObject* self, PyObject* args)
 
   //Reservation tableau travail temporaire
   PyObject* drodm2Array = PyDict_GetItemString(work,"hors_eq"); FldArrayF* drodm2;
-  K_NUMPY::getFromNumpyArray(drodm2Array, drodm2, true); E_Float* iptroflt = drodm2->begin();
+  K_NUMPY::getFromNumpyArray(drodm2Array, drodm2); E_Float* iptroflt = drodm2->begin();
 
   E_Int shift_dom   = 0;
   E_Int shift_roflt = 0;

--- a/Fast/Fast/Fast/INTERP/interplbmns_.cpp
+++ b/Fast/Fast/Fast/INTERP/interplbmns_.cpp
@@ -45,7 +45,7 @@ PyObject* K_FAST::interplbmns_(PyObject* self, PyObject* args)
   }
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];

--- a/Fast/Fast/Fast/INTERP/recuplbmns_.cpp
+++ b/Fast/Fast/Fast/INTERP/recuplbmns_.cpp
@@ -84,7 +84,7 @@ PyObject* K_FAST::recuplbmns_(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   PyObject* interpArray = PyDict_GetItemString(work,"tab_interp"); FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(interpArray, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(interpArray, stk); E_Float* iptstk = stk->begin();
 
   E_Int stk_size    = stk[0].getSize();
   //cout << "taille tab stockage " << stk_size << endl;
@@ -94,10 +94,10 @@ PyObject* K_FAST::recuplbmns_(PyObject* self, PyObject* args)
   /* Extraction tableau int et real de tc */
   /*--------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
 
   //cout << vartype << nvars << endl;

--- a/Fast/Fast/Fast/computePT.cpp
+++ b/Fast/Fast/Fast/computePT.cpp
@@ -74,7 +74,7 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;
@@ -105,11 +105,11 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
       pyParam_real_tc= PyDict_GetItemString(work,"param_real_tc");
 
       if (pyParam_int_tc != Py_None)
-	{ K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc , true); ipt_param_int_tc = param_int_tc -> begin(); }
+	{ K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc ); ipt_param_int_tc = param_int_tc -> begin(); }
       else{ ipt_param_int_tc = NULL;}
 
       if (pyParam_real_tc != Py_None)
-	{ K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc, true); ipt_param_real_tc= param_real_tc-> begin(); }
+	{ K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc); ipt_param_real_tc= param_real_tc-> begin(); }
       else{ ipt_param_real_tc = NULL; }
 
   if( layer_mode ==1)
@@ -117,17 +117,17 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
 
       pyLinlets_int = PyDict_GetItemString(work,"linelets_int");
       if (pyLinlets_int != Py_None)
-	{K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int, true); ipt_linelets_int = linelets_int->begin();}
+	{K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int); ipt_linelets_int = linelets_int->begin();}
       else{ipt_linelets_int = NULL;}
 
       pyLinlets_real = PyDict_GetItemString(work,"linelets_real");
       if (pyLinlets_real != Py_None)
-	{K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real, true); ipt_linelets_real = linelets_real->begin();}
+	{K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real); ipt_linelets_real = linelets_real->begin();}
       else{ipt_linelets_real = NULL;}
 
 
       iskipArray = PyDict_GetItemString(work,"skip_lu");
-      K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu, true); ipt_iskip_lu = iskip_lu->begin();
+      K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu); ipt_iskip_lu = iskip_lu->begin();
 
       PyObject* tmp1 = PyDict_GetItemString(work,"lssiter_loc");
       if (PyLong_Check(tmp1) == true) lssiter_loc = PyLong_AsLong(tmp1);
@@ -505,12 +505,12 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
 
   /// Tableau pour stockage senseur oscillation
   PyObject* wigArray = PyDict_GetItemString(work,"wiggle"); FldArrayF* wig;
-  K_NUMPY::getFromNumpyArray(wigArray, wig, true); E_Float* iptwig = wig->begin();
+  K_NUMPY::getFromNumpyArray(wigArray, wig); E_Float* iptwig = wig->begin();
 
 
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
 
   iptdrodm_transfer[0]= iptdrodm;
   for (E_Int nd = 1; nd < nidom; nd++){ iptdrodm_transfer[nd]= iptdrodm_transfer[nd-1] + ipt_param_int[nd-1][NEQ]*ipt_param_int[nd-1][NDIMDX];}
@@ -518,45 +518,45 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
 
   // LBM : tableau de stockage pour la distribution hors equilibre
   PyObject* drodm2Array = PyDict_GetItemString(work,"hors_eq"); FldArrayF* drodm2;
-  K_NUMPY::getFromNumpyArray(drodm2Array, drodm2, true); E_Float* f_horseq = drodm2->begin();
+  K_NUMPY::getFromNumpyArray(drodm2Array, drodm2); E_Float* f_horseq = drodm2->begin();
 
   // Tableaux de travail pour HRR O2
   PyObject* tab_a1prArray = PyDict_GetItemString(work,"a1_pr"); FldArrayF* tab_a1pr;
-  K_NUMPY::getFromNumpyArray(tab_a1prArray, tab_a1pr, true); E_Float* a1_pr = tab_a1pr->begin();
+  K_NUMPY::getFromNumpyArray(tab_a1prArray, tab_a1pr); E_Float* a1_pr = tab_a1pr->begin();
 
   PyObject* tab_a1fdArray = PyDict_GetItemString(work,"a1_fd"); FldArrayF* tab_a1fd;
-  K_NUMPY::getFromNumpyArray(tab_a1fdArray, tab_a1fd, true); E_Float* a1_fd = tab_a1fd->begin();
+  K_NUMPY::getFromNumpyArray(tab_a1fdArray, tab_a1fd); E_Float* a1_fd = tab_a1fd->begin();
 
   PyObject* tab_a1hrArray = PyDict_GetItemString(work,"a1_hr"); FldArrayF* tab_a1hr;
-  K_NUMPY::getFromNumpyArray(tab_a1hrArray, tab_a1hr, true); E_Float* a1_hrr = tab_a1hr->begin();
+  K_NUMPY::getFromNumpyArray(tab_a1hrArray, tab_a1hr); E_Float* a1_hrr = tab_a1hr->begin();
 
   // Tableau de travail pour HRR O3
   PyObject* tab_a3Array = PyDict_GetItemString(work,"aneq_3"); FldArrayF* tab_a3;
-  K_NUMPY::getFromNumpyArray(tab_a3Array, tab_a3, true); E_Float* aneq_o3 = tab_a3->begin();
+  K_NUMPY::getFromNumpyArray(tab_a3Array, tab_a3); E_Float* aneq_o3 = tab_a3->begin();
 
   PyObject* tab_psiArray  = PyDict_GetItemString(work,"psi_corr"); FldArrayF* tab_psi;
-  K_NUMPY::getFromNumpyArray(tab_psiArray, tab_psi, true); E_Float* psi_corr = tab_psi->begin();
+  K_NUMPY::getFromNumpyArray(tab_psiArray, tab_psi); E_Float* psi_corr = tab_psi->begin();
 
 
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* fluArray = PyDict_GetItemString(work,"flu_vecto"); FldArrayF* flu;
-  K_NUMPY::getFromNumpyArray(fluArray, flu, true); E_Float* iptflu = flu->begin();
+  K_NUMPY::getFromNumpyArray(fluArray, flu); E_Float* iptflu = flu->begin();
 
   // Tableau de travail gradient
   PyObject* gradArray = PyDict_GetItemString(work,"grad"); FldArrayF* grad;
-  K_NUMPY::getFromNumpyArray(gradArray, grad, true); E_Float* iptgrad = grad->begin();
+  K_NUMPY::getFromNumpyArray(gradArray, grad); E_Float* iptgrad = grad->begin();
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
   // Tableau de travail timer omp
   PyObject*  timer_omp_Array= PyDict_GetItemString(work,"TIMER_OMP"); FldArrayF* tab_timer_omp;
-  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp, true); E_Float* timer_omp = tab_timer_omp->begin();
+  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp); E_Float* timer_omp = tab_timer_omp->begin();
 
 
  /// Recuperation du tableau de stockage dtloc
@@ -568,7 +568,7 @@ PyObject* K_FAST::_computePT(PyObject* self, PyObject* args)
   //if (ipt_param_int[0][ITYPCP]==2 and ipt_param_int[0][EXPLOC]==2 and ipt_param_int[0][RK]==3 and layer_mode ==1)
   {
     dtloc_stk = PyDict_GetItemString(work,"tab_dtloc");
-    K_NUMPY::getFromNumpyArray(dtloc_stk, stk, true);  iptstk = stk->begin();
+    K_NUMPY::getFromNumpyArray(dtloc_stk, stk);  iptstk = stk->begin();
 
     stk_size    = stk[0].getSize();
     taille_tabs = stk_size/5;

--- a/Fast/Fast/Fast/gsdr3.cpp
+++ b/Fast/Fast/Fast/gsdr3.cpp
@@ -249,8 +249,9 @@ E_Int rank =0;
         //---------------------------------------------------------------------
         // -----Boucle sur num.les domaines de la configuration
         // ---------------------------------------------------------------------
-        E_Int shift_zone=0; E_Int shift_wig=0; E_Int shift_coe=0; E_Int nd_current=0;E_Int shift_rk4=0;  E_Int shift_grad=0;
-        E_Int shift_a1=0;   E_Int shift_a3=0;  E_Int shift_a4=0;
+        E_Int nd_current=0;
+        int64_t shift_zone=0; int64_t shift_wig=0; int64_t shift_coe=0; int64_t shift_grad=0;
+        int64_t shift_a1=0;   int64_t shift_a3=0;  int64_t shift_a4=0;
 	E_Float rhs_end=0; E_Int ncells=0;
 
         E_Int nbtask = ipt_omp[nitcfg-1];

--- a/Fast/FastC/FastC/Compute/souszones_list.cpp
+++ b/Fast/FastC/FastC/Compute/souszones_list.cpp
@@ -108,7 +108,7 @@ PyObject* K_FASTC::souszones_list(PyObject* self, PyObject* args)
 
   // Tableau de parametre schema temporel
   PyObject* dtlocArray  = PyDict_GetItemString(work, "dtloc"); FldArrayI*  dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc = dtloc->begin();
 
   E_Int nidom = PyList_Size(zones);
 
@@ -123,7 +123,7 @@ PyObject* K_FASTC::souszones_list(PyObject* self, PyObject* args)
   else mx_omp_size_int = PyInt_AsLong(tmp);
 
   PyObject* iskipArray = PyDict_GetItemString(work,"skip_lu"); FldArrayI* iskip_lu;
-  K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu, true); E_Int* ipt_iskip_lu = iskip_lu->begin();
+  K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu); E_Int* ipt_iskip_lu = iskip_lu->begin();
 
  
   E_Int**   ipt_param_int;  E_Int** ipt_ind_dm; E_Int** ipt_it_lu_ssdom; E_Float** ipt_param_real;

--- a/Fast/FastC/FastC/Init/initNuma.cpp
+++ b/Fast/FastC/FastC/Init/initNuma.cpp
@@ -51,8 +51,8 @@ PyObject* K_FASTC::initNuma(PyObject* self, PyObject* args)
   }
 
   FldArrayF* source; FldArrayF* target;
-  K_NUMPY::getFromNumpyArray(sourceArray, source, true); E_Float* iptsource = source->begin();
-  K_NUMPY::getFromNumpyArray(targetArray, target, true); E_Float* ipttarget = target->begin();
+  K_NUMPY::getFromNumpyArray(sourceArray, source); E_Float* iptsource = source->begin();
+  K_NUMPY::getFromNumpyArray(targetArray, target); E_Float* ipttarget = target->begin();
 
 
   vector<PyArrayObject*> hook;

--- a/Fast/FastC/FastC/Metric/init_metric.cpp
+++ b/Fast/FastC/FastC/Metric/init_metric.cpp
@@ -44,7 +44,7 @@ PyObject* K_FASTC::init_metric(PyObject* self, PyObject* args)
 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];

--- a/Fast/FastC/FastC/getRange.cpp
+++ b/Fast/FastC/FastC/getRange.cpp
@@ -37,9 +37,9 @@ PyObject* K_FASTC::PygetRange( PyObject* self, PyObject* args ) {
 
     FldArrayI* ind_bc;
     FldArrayI* param_int;
-    K_NUMPY::getFromNumpyArray( ind_bcArray, ind_bc, true );
+    K_NUMPY::getFromNumpyArray( ind_bcArray, ind_bc );
     E_Int* ipt_ind_bc = ind_bc->begin( );
-    K_NUMPY::getFromNumpyArray( param_intArray, param_int, true );
+    K_NUMPY::getFromNumpyArray( param_intArray, param_int );
     E_Int* ipt_param_int = param_int->begin( );
 
     getRange( ipt_ind_bc, ipt_param_int + shift + 1, ipt_param_int );

--- a/Fast/FastS/FastS/ADJOINT/compute_dpJ_dpW.cpp
+++ b/Fast/FastS/FastS/ADJOINT/compute_dpJ_dpW.cpp
@@ -85,8 +85,7 @@ PyObject* K_FASTS::compute_dpJ_dpW(PyObject* self, PyObject* args)
 
   /// Tableau pour stockage senseur oscillation
   PyObject* wigArray = PyDict_GetItemString(work,"wiggle"); FldArrayF* wig; FldArrayF* eff;
-  K_NUMPY::getFromNumpyArray(wigArray, wig, true); E_Float* iptwig = wig->begin();
-//  K_NUMPY::getFromNumpyArray(effarray, eff, true); E_Float* ipteff = eff->begin();
+  K_NUMPY::getFromNumpyArray(wigArray, wig); E_Float* iptwig = wig->begin();
 
   
   ///

--- a/Fast/FastS/FastS/BC/applyBC.cpp
+++ b/Fast/FastS/FastS/BC/applyBC.cpp
@@ -46,7 +46,7 @@ PyObject* K_FASTS::_applyBC(PyObject* self, PyObject* args)
   PyObject* tmp = PyDict_GetItemString(work,"MX_SSZONE");  E_Int mx_sszone = PyLong_AsLong(tmp);
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;

--- a/Fast/FastS/FastS/BC/compute_effort.cpp
+++ b/Fast/FastS/FastS/BC/compute_effort.cpp
@@ -81,13 +81,13 @@ PyObject* K_FASTS::compute_effort(PyObject* self, PyObject* args)
 
   /// Tableau pour stockage senseur oscillation
   PyObject* wigArray = PyDict_GetItemString(work,"wiggle"); FldArrayF* wig; FldArrayF* eff; FldArrayF* pos;
-  K_NUMPY::getFromNumpyArray(wigArray, wig, true); E_Float* iptwig = wig->begin();
-  K_NUMPY::getFromNumpyArray(effarray, eff, true); E_Float* ipteff = eff->begin();
-  K_NUMPY::getFromNumpyArray(pos_eff , pos, true); E_Float* xyz_ref= pos->begin();
+  K_NUMPY::getFromNumpyArray(wigArray, wig); E_Float* iptwig = wig->begin();
+  K_NUMPY::getFromNumpyArray(effarray, eff); E_Float* ipteff = eff->begin();
+  K_NUMPY::getFromNumpyArray(pos_eff , pos); E_Float* xyz_ref= pos->begin();
 
   /// Tableau pour // omp
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[ 8 ];
   E_Int shift_omp= iptdtloc[11];

--- a/Fast/FastS/FastS/Compute/DTLOC/BC_local.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/BC_local.cpp
@@ -37,24 +37,9 @@ void K_FASTS::BC_local(E_Float**& iptro, E_Float**& iptro_p1, E_Int*& ipt_param_
 
 
 
-  E_Int a=0;
-  E_Int b=0;
-  E_Int* shift_zone = new E_Int[nidom];
-  E_Int* shift_coe  = new E_Int[nidom];
   E_Int process = 1;
   E_Int lrhs=0; E_Int lcorner=0; 
   E_Int npass         = 0;
-
-  for (E_Int nd = 0; nd < nidom; nd++)
-    {
-      shift_zone[nd]=a;
-      a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-    }
-  for (E_Int nd = 0; nd < nidom; nd++)
-    {
-      shift_coe[nd]=b;
-      b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-    }
 
 #pragma omp parallel default(shared) //private(cycle)
   {
@@ -380,9 +365,6 @@ void K_FASTS::BC_local(E_Float**& iptro, E_Float**& iptro_p1, E_Int*& ipt_param_
       } // boucle NoTransfert
 
   }// fin zone omp 
-
-
-delete [] shift_zone; delete [] shift_coe;
 
 
 }

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal.cpp
@@ -86,22 +86,22 @@ PyObject* K_FASTS::dtlocal(PyObject* self, PyObject* args)
  
  /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /// Recuperation du tableau de stockage des flux
   FldArrayF* drodmstk;
-  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk, true); E_Float* iptdrodmstk = drodmstk->begin();
+  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk); E_Float* iptdrodmstk = drodmstk->begin();
 
   /// Recuperation du tableau de stockage des flux pour conservativite
   FldArrayF* cstk;
-  K_NUMPY::getFromNumpyArray(constk, cstk, true); E_Float* iptcstk = cstk->begin();
+  K_NUMPY::getFromNumpyArray(constk, cstk); E_Float* iptcstk = cstk->begin();
   //// Recuperation du tableau drodm
   PyObject* drodmArray = PyList_GetItem(work,2); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
 
   /// Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyList_GetItem(work,1); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
 
  
@@ -109,10 +109,10 @@ PyObject* K_FASTS::dtlocal(PyObject* self, PyObject* args)
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
 
   E_Int nvars;
@@ -133,34 +133,20 @@ PyObject* K_FASTS::dtlocal(PyObject* self, PyObject* args)
   E_Int ech  = ipt_param_int[ NoTransfert ];
   E_Int nrac = ipt_param_int[ ech +1 ];
   E_Int cycle;
-  E_Int a=0;
-  E_Int b=0;
-  E_Int shift_zone[nidomR];
-  E_Int shift_coe [nidomR];
+  int64_t shift_zone[nidomR];
+  int64_t shift_coe[nidomR];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidomR; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ_COE ];	 
+    }
 
-     for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-       }
-      for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-       }
+  E_Int taille=20000000/nrac;
 
-      E_Int taille=20000000/nrac;
-
-      vector<E_Int> stockzone(nidomR,-1);
-      vector<E_Int> nbraczone(nidomR,0);
-
-
-
-
-
-
-
-
+  vector<E_Int> stockzone(nidomR,-1);
+  vector<E_Int> nbraczone(nidomR,0);
 
 
  

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2.cpp
@@ -87,22 +87,22 @@ PyObject* K_FASTS::dtlocal2(PyObject* self, PyObject* args)
  
  /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /// Recuperation du tableau de stockage des flux
   FldArrayF* drodmstk;
-  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk, true); E_Float* iptdrodmstk = drodmstk->begin();
+  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk); E_Float* iptdrodmstk = drodmstk->begin();
 
   /// Recuperation du tableau de stockage des flux pour conservativite
   FldArrayF* cstk;
-  K_NUMPY::getFromNumpyArray(constk, cstk, true); E_Float* iptcstk = cstk->begin();
+  K_NUMPY::getFromNumpyArray(constk, cstk); E_Float* iptcstk = cstk->begin();
   //// Recuperation du tableau drodm
   PyObject* drodmArray = PyList_GetItem(work,2); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
 
   /// Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyList_GetItem(work,1); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
 
  
@@ -110,10 +110,10 @@ PyObject* K_FASTS::dtlocal2(PyObject* self, PyObject* args)
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
 
   E_Int nvars;
@@ -134,21 +134,15 @@ PyObject* K_FASTS::dtlocal2(PyObject* self, PyObject* args)
   E_Int ech  = ipt_param_int[ NoTransfert ];
   E_Int nrac = ipt_param_int[ ech +1 ];
   E_Int cycle;
-  E_Int a=0;
-  E_Int b=0;
-  E_Int shift_zone[nidomR];
-  E_Int shift_coe [nidomR];
-
-     for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-       }
-      for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-       }
+  int64_t shift_zone[nidomR];
+  int64_t shift_coe[nidomR];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidomR; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ_COE ];	 
+    }
 
       E_Int taille=200000000/nrac;
 

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para.cpp
@@ -90,22 +90,22 @@ PyObject* K_FASTS::dtlocal2para(PyObject* self, PyObject* args)
  
  /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /// Recuperation du tableau de stockage des flux
   FldArrayF* drodmstk;
-  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk, true); E_Float* iptdrodmstk = drodmstk->begin();
+  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk); E_Float* iptdrodmstk = drodmstk->begin();
 
   /// Recuperation du tableau de stockage des flux pour conservativite
   FldArrayF* cstk;
-  K_NUMPY::getFromNumpyArray(constk, cstk, true); E_Float* iptcstk = cstk->begin();
+  K_NUMPY::getFromNumpyArray(constk, cstk); E_Float* iptcstk = cstk->begin();
   //// Recuperation du tableau drodm
   PyObject* drodmArray = PyList_GetItem(work,2); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
 
   /// Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyList_GetItem(work,1); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
 
  
@@ -113,10 +113,10 @@ PyObject* K_FASTS::dtlocal2para(PyObject* self, PyObject* args)
   /* Extraction tableau int et real de tc*/
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
 
   E_Int nvars;
@@ -140,23 +140,17 @@ PyObject* K_FASTS::dtlocal2para(PyObject* self, PyObject* args)
   omp_mode = 0;
 
 
-  E_Int a=0;
-  E_Int b=0;
-  E_Int shift_zone[nidomR];
-  E_Int shift_coe [nidomR];
+  int64_t shift_zone[nidomR];
+  int64_t shift_coe [nidomR];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidomR; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ_COE ];	 
+    }
 
-     for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-       }
-      for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-       }
-
-      E_Int taille=taille_tabs/nrac;
+  E_Int taille=taille_tabs/nrac;
 
 
   vector<E_Int> nbraczone(nidomR,0);

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_.cpp
@@ -77,7 +77,7 @@ PyObject* K_FASTS::dtlocal2para_(PyObject* self, PyObject* args)
 
  /// Recuperation du tableau de stockage des valeurs
   PyObject* dtlocArray = PyDict_GetItemString(work,"tab_dtloc"); FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(dtlocArray, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, stk); E_Float* iptstk = stk->begin();
 
   E_Int stk_size    = stk[0].getSize();
   E_Int taille_tabs = stk_size/5;
@@ -87,17 +87,17 @@ PyObject* K_FASTS::dtlocal2para_(PyObject* self, PyObject* args)
 
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
   
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true); E_Int* ipt_param_int = param_int->begin();
+  K_NUMPY::getFromNumpyArray(pyParam_int, param_int); E_Int* ipt_param_int = param_int->begin();
 
   ///// Les shifts pour les zones /////
 
@@ -108,24 +108,18 @@ PyObject* K_FASTS::dtlocal2para_(PyObject* self, PyObject* args)
   E_Int ech         = ipt_param_int[ NoTransfert +shift_graph];
   E_Int nrac        = ipt_param_int[ ech +1 ];
 
-  E_Int a=0;
-  E_Int b=0;
-  E_Int shift_zone[nidomR];
-  E_Int shift_coe [nidomR];
+  int64_t shift_zone[nidomR];
+  int64_t shift_coe[nidomR];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidomR; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ_COE ];	 
+    }
 
-     for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-       }
-      for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-       }
-
-      E_Int taille_stk       = taille_tabs*3/nrac;
-      E_Int taille_drodmstk  = taille_tabs/nrac;
+  E_Int taille_stk       = taille_tabs*3/nrac;
+  E_Int taille_drodmstk  = taille_tabs/nrac;
 
 
   vector<E_Int> nbraczone(nidomR,0);

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_c.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_c.cpp
@@ -37,19 +37,14 @@ void K_FASTS::dtlocal2para_c(E_Float**& iptro, E_Float**& iptro_p1,
 
   E_Int omp_mode = 0;
 
-  E_Int shift_zone[nidom];
-  E_Int shift_coe[nidom];
-  E_Int a=0;
-  E_Int b=0;
-  for (E_Int nd = 0; nd < nidom; nd++)
+  int64_t shift_zone[nidom];
+  int64_t shift_coe[nidom];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidom; nd++)
     {
-      shift_zone[nd]=a;
-      a=a+param_int[nd][ NDIMDX ]*param_int[nd][ NEQ ];	 
-    }
-  for (E_Int nd = 0; nd < nidom; nd++)
-    {
-      shift_coe[nd]=b;
-      b=b+param_int[nd][ NDIMDX ]*param_int[nd][ NEQ_COE ];	 
+      shift_zone[nd] = shift_zone[nd-1] + param_int[nd-1][ NDIMDX ]*param_int[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_int[nd-1][ NDIMDX ]*param_int[nd-1][ NEQ_COE ];	 
     }
 
 #pragma omp parallel default(shared) //private(cycle)

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_mpi.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_mpi.cpp
@@ -75,7 +75,7 @@ PyObject* K_FASTS::dtlocal2para_mpi(PyObject* self, PyObject* args)
 
  /// Recuperation du tableau de stockage des valeurs
   PyObject* dtlocArray = PyDict_GetItemString(work,"tab_dtloc"); FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(dtlocArray, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, stk); E_Float* iptstk = stk->begin();
 
   E_Int stk_size    = stk[0].getSize();
   E_Int taille_tabs = stk_size/5;
@@ -85,37 +85,27 @@ PyObject* K_FASTS::dtlocal2para_mpi(PyObject* self, PyObject* args)
   
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
   
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true); E_Int* ipt_param_int = param_int->begin();
+  K_NUMPY::getFromNumpyArray(pyParam_int, param_int); E_Int* ipt_param_int = param_int->begin();
 
-  E_Int a=0;
-  E_Int b=0;
-  E_Int shift_zone[nidomR];
-  E_Int shift_coe [nidomR];
-
-     for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ ];	 
-       }
-      for (E_Int nd = 0; nd < nidomR; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_intt[nd][ NDIMDX ]*param_intt[nd][ NEQ_COE ];	 
-       }
-
-      //E_Int taille_stk       = taille_tabs*3;
-      //E_Int taille_drodmstk  = taille_tabs;
-
+  int64_t shift_zone[nidomR];
+  int64_t shift_coe[nidomR];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidomR; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_intt[nd-1][ NDIMDX ]*param_intt[nd-1][ NEQ_COE ];	 
+    }
 
   vector<E_Int> nbraczone(nidomR,0);
   vector<E_Int> stockzone(nidomR,-1);

--- a/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_sauv.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/dtlocal2para_sauv.cpp
@@ -91,32 +91,32 @@ PyObject* K_FASTS::dtlocal2para_(PyObject* self, PyObject* args)
  
  /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /// Recuperation du tableau de stockage des flux
   FldArrayF* drodmstk;
-  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk, true); E_Float* iptdrodmstk = drodmstk->begin();
+  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk); E_Float* iptdrodmstk = drodmstk->begin();
 
   /// Recuperation du tableau de stockage des flux pour conservativite
   FldArrayF* cstk;
-  K_NUMPY::getFromNumpyArray(constk, cstk, true); E_Float* iptcstk = cstk->begin();
+  K_NUMPY::getFromNumpyArray(constk, cstk); E_Float* iptcstk = cstk->begin();
 
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
   
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
 
   E_Int nvars;

--- a/Fast/FastS/FastS/Compute/DTLOC/recup.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup.cpp
@@ -49,7 +49,7 @@ PyObject* K_FASTS::recup(PyObject* self, PyObject* args)
    
   /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
    
   /// Recuperation de param_int

--- a/Fast/FastS/FastS/Compute/DTLOC/recup2.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup2.cpp
@@ -75,16 +75,16 @@ PyObject* K_FASTS::recup2(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
   
 

--- a/Fast/FastS/FastS/Compute/DTLOC/recup3.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup3.cpp
@@ -75,16 +75,16 @@ PyObject* K_FASTS::recup3(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
   
 

--- a/Fast/FastS/FastS/Compute/DTLOC/recup3para.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup3para.cpp
@@ -77,16 +77,16 @@ PyObject* K_FASTS::recup3para(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true);
+  E_Int res_donor = K_NUMPY::getFromNumpyArray(pyParam_int, param_int);
   E_Int* ipt_param_int = param_int->begin();
   FldArrayF* param_real;
-  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real, true);
+  res_donor = K_NUMPY::getFromNumpyArray(pyParam_real, param_real);
   E_Float* ipt_param_real = param_real->begin();
   
 

--- a/Fast/FastS/FastS/Compute/DTLOC/recup3para_.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup3para_.cpp
@@ -73,7 +73,7 @@ PyObject* K_FASTS::recup3para_(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   PyObject* dtlocArray = PyDict_GetItemString(work,"tab_dtloc"); FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(dtlocArray, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, stk); E_Float* iptstk = stk->begin();
 
   E_Int stk_size    = stk[0].getSize();
   E_Int taille_tabs = stk_size/5;
@@ -81,7 +81,7 @@ PyObject* K_FASTS::recup3para_(PyObject* self, PyObject* args)
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true); E_Int* ipt_param_int = param_int->begin();
+  K_NUMPY::getFromNumpyArray(pyParam_int, param_int); E_Int* ipt_param_int = param_int->begin();
   
   E_Int nbcomIBC = ipt_param_int[1];
   E_Int nbcomID  = ipt_param_int[2+nbcomIBC];

--- a/Fast/FastS/FastS/Compute/DTLOC/recup3para_mpi.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/recup3para_mpi.cpp
@@ -73,12 +73,12 @@ PyObject* K_FASTS::recup3para_mpi(PyObject* self, PyObject* args)
 
   /// Recuperation du tableau de stockage des valeurs
   PyObject* dtlocArray = PyDict_GetItemString(work,"tab_dtloc"); FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(dtlocArray, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, stk); E_Float* iptstk = stk->begin();
   /*-------------------------------------*/
   /* Extraction tableau int et real      */
   /*-------------------------------------*/
   FldArrayI* param_int;
-  K_NUMPY::getFromNumpyArray(pyParam_int, param_int, true); E_Int* ipt_param_int = param_int->begin();
+  K_NUMPY::getFromNumpyArray(pyParam_int, param_int); E_Int* ipt_param_int = param_int->begin();
   
 #pragma omp parallel default(shared) //private(cycle)
   {

--- a/Fast/FastS/FastS/Compute/DTLOC/stockrecup.cpp
+++ b/Fast/FastS/FastS/Compute/DTLOC/stockrecup.cpp
@@ -53,23 +53,23 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
   
   /// Recuperation du tableau de stockage des valeurs
   FldArrayF* stk;
-  K_NUMPY::getFromNumpyArray(stock, stk, true); E_Float* iptstk = stk->begin();
+  K_NUMPY::getFromNumpyArray(stock, stk); E_Float* iptstk = stk->begin();
 
   /// Recuperation du tableau de stockage des flux
   FldArrayF* drodmstk;
-  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk, true); E_Float* iptdrodmstk = drodmstk->begin();
+  K_NUMPY::getFromNumpyArray(drodmstock,drodmstk); E_Float* iptdrodmstk = drodmstk->begin();
 
   /// Recuperation du tableau de stockage des flux pour conservativite
   FldArrayF* cstk;
-  K_NUMPY::getFromNumpyArray(constk, cstk, true); E_Float* iptcstk = cstk->begin();
+  K_NUMPY::getFromNumpyArray(constk, cstk); E_Float* iptcstk = cstk->begin();
 
   /// Recuperation du tableau des flux (drodm)
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
    
   /// Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   /// Recuperation de param_int, param_real,rop et rop_tmp
   for (E_Int nd = 0; nd < nidom; nd++)
@@ -100,26 +100,15 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
   E_Int c=0;
   E_Int shift;
   E_Int cycle;
-  E_Int a;
-  a=0;
-  E_Int b;
-  b=0;
-  E_Int shift_zone[nidom];
-  E_Int shift_coe[nidom];
-
-     for (E_Int nd = 0; nd < nidom; nd++)
-       {
-	 shift_zone[nd]=a;
-	 a=a+param_int[nd][ NDIMDX ]*param_int[nd][ NEQ ];
-	 //cout << "ndimdx= " << param_int[nd][ NDIMDX ] << endl;
-       }
-      for (E_Int nd = 0; nd < nidom; nd++)
-       {
-	 shift_coe[nd]=b;
-	 b=b+param_int[nd][ NDIMDX ]*param_int[nd][ NEQ_COE ];	 
-       }
-
-
+  int64_t shift_zone[nidom];
+  int64_t shift_coe[nidom];
+  shift_zone[0]=0;
+  shift_coe[0] =0;
+  for (E_Int nd = 1; nd < nidom; nd++)
+    {
+      shift_zone[nd] = shift_zone[nd-1] + param_int[nd-1][ NDIMDX ]*param_int[nd-1][ NEQ ];
+      shift_coe[nd ] = shift_coe[nd -1] + param_int[nd-1][ NDIMDX ]*param_int[nd-1][ NEQ_COE ];	 
+    }
 
    if (param_int[0][RK]==2 and param_int[0][EXPLOC]==1) // Mon schéma
       {      
@@ -186,15 +175,7 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[3]=  param_int[nd][IJKV+1];
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
-		   		   
-		   for (E_Int n = 0; n < nd+1 ; n++)
-		     //for (E_Int n = 0; n < 0 ; n++)
-		     {
-		       c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		    shift=c;
-		    //cout <<"shift_coe= "<< shift_coe[nd] << endl;
-
+		  
 		    c=nd+1;
 		    //c = nd+2;
 		    //c=0;
@@ -203,7 +184,7 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 
 
 
-		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c],iptcstk,iptcoe+shift_coe[nd],nstep,nd);
 		   c=0; 
 
 		   //cout << "coucou conservativite 3" << endl;
@@ -220,13 +201,6 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   	      
-		   for (E_Int n = 0; n < nd-1 ; n++)
-		   //for (E_Int n = 0; n < 0 ; n++)
-		      {
-		              c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		   
-		   shift=c;
 		   //cout <<"c(cons2)=  "<< c << endl;
 		   //c=nd-1;
 		   c=nd-1;
@@ -236,7 +210,7 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 
 		   //cout << "coucou conservativite 3" << endl;
 
-		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c],iptcstk,iptcoe+shift_coe[nd],nstep,nd);
 		   c=0;
 
 		   //cout << "coucou conservativite 3" << endl;
@@ -315,17 +289,10 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   		   
-		   for (E_Int n = 0; n < nd+1 ; n++)
-		   //for (E_Int n = 0; n < 0 ; n++)
-		      {
-		       c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		    shift=c;
-		    //cout <<"c=  "<< c << endl;
 		    c=nd+1;
 		    //c=0;
 		   imax=1;
-		   //conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   //conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0;  
 		}
 	      else if(param_int[nd][LEVELG]>param_int[nd][LEVEL] and param_int[nd][LEVEL]>param_int[nd][LEVELD]) /// savoir quelles colonnes on prend
@@ -340,20 +307,12 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   	      
-		   for (E_Int n = 0; n < nd-1 ; n++)
-		   //for (E_Int n = 0; n < 0 ; n++)
-		      {
-		              c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		   
-		   shift=c;
-		   //cout <<"c(cons2)= "<< c << endl;
 		   c=nd-1;
 		   //c=0;
 		   imax=param_int[c][IJKV];
 		   //cout <<"param(IJKV)(cons2)= "<< imax << endl;
 		 
-		   //conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   //conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0;
 		   
 		}
@@ -461,20 +420,13 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   		   
-		   for (E_Int n = 0; n < nd+1 ; n++)
-		     {
-		       c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		    shift=c;
-		    //cout <<"shift_coe= "<< shift_coe[nd] << endl;
-
 		   c=nd+1;
 		   //cout <<"c=  "<< c << endl;
 		   imax=1;
 
 		   //cout << "coucou conservativite 3" << endl;
 
-		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0; 
 
 		   //cout << "coucou conservativite 3" << endl;
@@ -491,20 +443,13 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   	      
-		   for (E_Int n = 0; n < nd-1 ; n++)
-		      {
-		              c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		   
-		   shift=c;
-		   //cout <<"c(cons2)=  "<< c << endl;
 		   c=nd-1;
 		   imax=param_int[c][IJKV];
 		   //cout <<"param(IJKV)(cons2)=  "<< imax << endl;
 
 		   //cout << "coucou conservativite 3" << endl;
 
-		   conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0;
 
 		   //cout << "coucou conservativite 3" << endl;
@@ -583,15 +528,9 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   		   
-		   for (E_Int n = 0; n < nd+1 ; n++)
-		      {
-		       c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		    shift=c;
-		    //cout <<"c=  "<< c << endl;
 		   c=nd+1; 
 		   imax=1;
-		   //conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   //conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0;  
 		}
 	      else if(param_int[nd][LEVELG]>param_int[nd][LEVEL] and param_int[nd][LEVEL]>param_int[nd][LEVELD]) /// savoir quelles colonnes on prend
@@ -606,18 +545,11 @@ PyObject* K_FASTS::stockrecup(PyObject* self, PyObject* args)
 		   ind_loop[4]=  1;
 		   ind_loop[5]=  param_int[nd][IJKV+2];
 		   	      
-		   for (E_Int n = 0; n < nd-1 ; n++)
-		      {
-		              c=c+param_int[n][ NDIMDX ]*param_int[n][ NEQ ];	 
-		      }
-		   
-		   shift=c;
-		   //cout <<"c(cons2)= "<< c << endl;
 		   c=nd-1;
 		   imax=param_int[c][IJKV];
 		   //cout <<"param(IJKV)(cons2)= "<< imax << endl;
 		 
-		   //conservativite32_(idir,param_int[nd],param_real[nd],param_int[c],ind_loop,imax,iptro[nd],iptdrodm + shift_zone[nd],iptdrodm + shift,iptcstk,iptcoe+shift_coe[nd],nstep,nd);
+		   //conservativite32_(idir,param_int[nd], param_real[nd], param_int[c], ind_loop, imax, iptro[nd], iptdrodm + shift_zone[nd],iptdrodm + shift_zone[c], iptcstk, iptcoe+shift_coe[nd], nstep, nd);
 		   c=0;
 		   
 		}

--- a/Fast/FastS/FastS/Compute/LES/computePT_mut.cpp
+++ b/Fast/FastS/FastS/Compute/LES/computePT_mut.cpp
@@ -48,7 +48,7 @@ PyObject* K_FASTS::_computePT_mut(PyObject* self, PyObject* args)
   PyObject* tmp = PyDict_GetItemString(work, "MX_SYNCHRO"); E_Int mx_synchro    = PyLong_AsLong(tmp); 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;
@@ -134,7 +134,7 @@ PyObject* K_FASTS::_computePT_mut(PyObject* self, PyObject* args)
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
 #pragma omp parallel default(shared)
   {

--- a/Fast/FastS/FastS/Compute/LU/allocate_ssor.cpp
+++ b/Fast/FastS/FastS/Compute/LU/allocate_ssor.cpp
@@ -43,7 +43,7 @@ PyObject* K_FASTS::allocate_ssor(PyObject* self, PyObject* args)
   E_Int *ipt_param_int, *ipt_ind_dm, *ipt_nidom_loc;
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];

--- a/Fast/FastS/FastS/Compute/Linear_solver/matvecPT.cpp
+++ b/Fast/FastS/FastS/Compute/Linear_solver/matvecPT.cpp
@@ -58,7 +58,7 @@ PyObject* K_FASTS::_matvecPT(PyObject* self, PyObject* args)
 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];
@@ -89,21 +89,21 @@ PyObject* K_FASTS::_matvecPT(PyObject* self, PyObject* args)
  pyParam_real_tc= PyDict_GetItemString(work,"param_real_tc"); 
 
  if (pyParam_int_tc != Py_None)
- { K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc , true); ipt_param_int_tc = param_int_tc -> begin(); }
+ { K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc ); ipt_param_int_tc = param_int_tc -> begin(); }
  else{ ipt_param_int_tc = NULL; }
 
  if (pyParam_real_tc != Py_None)
- { K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc, true); ipt_param_real_tc= param_real_tc-> begin(); }
+ { K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc); ipt_param_real_tc= param_real_tc-> begin(); }
  else{ ipt_param_real_tc = NULL; }
 
  pyLinlets_int = PyDict_GetItemString(work,"linelets_int");
  if (pyLinlets_int != Py_None)
- {K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int, true); ipt_linelets_int = linelets_int->begin();}
+ {K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int); ipt_linelets_int = linelets_int->begin();}
  else{ipt_linelets_int = NULL;}  
 
  pyLinlets_real = PyDict_GetItemString(work,"linelets_real");
  if (pyLinlets_real != Py_None)
- {K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real, true); ipt_linelets_real = linelets_real->begin();}
+ {K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real); ipt_linelets_real = linelets_real->begin();}
  else{ipt_linelets_real = NULL;}
 
 // Fin partie code specifique au Transfer Data
@@ -389,26 +389,26 @@ PyObject* K_FASTS::_matvecPT(PyObject* self, PyObject* args)
 
   /// Tableau pour stockage senseur oscillation
   PyObject* wigArray = PyDict_GetItemString(work,"wiggle"); FldArrayF* wig;
-  K_NUMPY::getFromNumpyArray(wigArray, wig, true); E_Float* iptwig = wig->begin();
+  K_NUMPY::getFromNumpyArray(wigArray, wig); E_Float* iptwig = wig->begin();
 
 
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
   iptdrodm_transfer[0]= iptdrodm;
   for (E_Int nd = 1; nd < nidom; nd++){ iptdrodm_transfer[nd]= iptdrodm_transfer[nd-1] + ipt_param_int[nd-1][NEQ]*ipt_param_int[nd-1][NDIMDX];}
   
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
   // Tableau de travail timer omp
   PyObject*  timer_omp_Array= PyDict_GetItemString(work,"TIMER_OMP"); FldArrayF* tab_timer_omp;
-  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp, true); E_Float* timer_omp = tab_timer_omp->begin();
+  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp); E_Float* timer_omp = tab_timer_omp->begin();
 
   //
   // On recupere ipt_param_int[nd][ ILES ] infos memoire  pour vectorisation du LU (inutile et pas present dans la base en scalaire)

--- a/Fast/FastS/FastS/Compute/computePT.cpp
+++ b/Fast/FastS/FastS/Compute/computePT.cpp
@@ -72,7 +72,7 @@ PyObject* K_FASTS::_computePT(PyObject* self, PyObject* args)
 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;
@@ -105,21 +105,21 @@ PyObject* K_FASTS::_computePT(PyObject* self, PyObject* args)
     pyParam_real_tc= PyDict_GetItemString(work,"param_real_tc"); 
 
     if (pyParam_int_tc != Py_None)
-    { K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc , true); ipt_param_int_tc = param_int_tc -> begin(); }
+    { K_NUMPY::getFromNumpyArray(pyParam_int_tc , param_int_tc ); ipt_param_int_tc = param_int_tc -> begin(); }
     else{ ipt_param_int_tc = NULL;}
 
     if (pyParam_real_tc != Py_None)
-    { K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc, true); ipt_param_real_tc= param_real_tc-> begin(); }
+    { K_NUMPY::getFromNumpyArray(pyParam_real_tc, param_real_tc); ipt_param_real_tc= param_real_tc-> begin(); }
     else{ ipt_param_real_tc = NULL; }
 
     pyLinlets_int = PyDict_GetItemString(work,"linelets_int");
     if (pyLinlets_int != Py_None)
-    {K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int, true); ipt_linelets_int = linelets_int->begin();}
+    {K_NUMPY::getFromNumpyArray(pyLinlets_int, linelets_int); ipt_linelets_int = linelets_int->begin();}
     else{ipt_linelets_int = NULL;}  
   
     pyLinlets_real = PyDict_GetItemString(work,"linelets_real");
     if (pyLinlets_real != Py_None)
-    {K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real, true); ipt_linelets_real = linelets_real->begin();}
+    {K_NUMPY::getFromNumpyArray(pyLinlets_real, linelets_real); ipt_linelets_real = linelets_real->begin();}
     else{ipt_linelets_real = NULL;}
   
     PyObject* tmp1 = PyDict_GetItemString(work,"lssiter_loc"); 
@@ -129,7 +129,7 @@ PyObject* K_FASTS::_computePT(PyObject* self, PyObject* args)
     //if(lcfl ==1)
     //{
       iskipArray = PyDict_GetItemString(work,"skip_lu");
-      K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu, true); ipt_iskip_lu = iskip_lu->begin();
+      K_NUMPY::getFromNumpyArray(iskipArray, iskip_lu); ipt_iskip_lu = iskip_lu->begin();
     //} 
  }
 else
@@ -446,12 +446,12 @@ else
 
   /// Tableau pour stockage senseur oscillation
   PyObject* wigArray = PyDict_GetItemString(work,"wiggle"); FldArrayF* wig;
-  K_NUMPY::getFromNumpyArray(wigArray, wig, true); E_Float* iptwig = wig->begin();
+  K_NUMPY::getFromNumpyArray(wigArray, wig); E_Float* iptwig = wig->begin();
 
 
   /// Tableau de travail communs explicite/implicite
   PyObject* drodmArray = PyDict_GetItemString(work,"rhs"); FldArrayF* drodm;
-  K_NUMPY::getFromNumpyArray(drodmArray, drodm, true); E_Float* iptdrodm = drodm->begin();
+  K_NUMPY::getFromNumpyArray(drodmArray, drodm); E_Float* iptdrodm = drodm->begin();
 
   iptdrodm_transfer[0]= iptdrodm;
   for (E_Int nd = 1; nd < nidom; nd++){ iptdrodm_transfer[nd]= iptdrodm_transfer[nd-1] + ipt_param_int[nd-1][NEQ]*ipt_param_int[nd-1][NDIMDX];}
@@ -459,15 +459,15 @@ else
   
   // Tableau de travail coe   ( dt/vol et diags LU)
   PyObject* coeArray = PyDict_GetItemString(work,"coe"); FldArrayF* coe;
-  K_NUMPY::getFromNumpyArray(coeArray, coe, true); E_Float* iptcoe = coe->begin();
+  K_NUMPY::getFromNumpyArray(coeArray, coe); E_Float* iptcoe = coe->begin();
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
   // Tableau de travail timer omp
   PyObject*  timer_omp_Array= PyDict_GetItemString(work,"TIMER_OMP"); FldArrayF* tab_timer_omp;
-  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp, true); E_Float* timer_omp = tab_timer_omp->begin();
+  K_NUMPY::getFromNumpyArray(timer_omp_Array, tab_timer_omp); E_Float* timer_omp = tab_timer_omp->begin();
 
 
  /// Recuperation du tableau de stockage dtloc
@@ -479,7 +479,7 @@ else
   //if (ipt_param_int[0][ITYPCP]==2 and ipt_param_int[0][EXPLOC]==2 and ipt_param_int[0][RK]==3 and layer_mode ==1)
   {
     dtloc_stk = PyDict_GetItemString(work,"tab_dtloc"); 
-    K_NUMPY::getFromNumpyArray(dtloc_stk, stk, true);  iptstk = stk->begin();
+    K_NUMPY::getFromNumpyArray(dtloc_stk, stk);  iptstk = stk->begin();
 
     stk_size    = stk[0].getSize();
     taille_tabs = stk_size/5;

--- a/Fast/FastS/FastS/Compute/computePT_laplacien.cpp
+++ b/Fast/FastS/FastS/Compute/computePT_laplacien.cpp
@@ -66,7 +66,7 @@ PyObject* K_FASTS::_computePT_laplacien(PyObject* self, PyObject* args)
 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;

--- a/Fast/FastS/FastS/Compute/gsdr3.cpp
+++ b/Fast/FastS/FastS/Compute/gsdr3.cpp
@@ -266,11 +266,11 @@ if(nitcfg==1){param_real[0][TEMPS] = 0.0;}
         //---------------------------------------------------------------------
         // -----Boucle sur num.les domaines de la configuration
         // ---------------------------------------------------------------------
-        E_Int shift_zone=0; E_Int shift_wig=0; E_Int shift_coe=0; E_Int shift_mu=0; E_Int nd_current=0;
+        //E_Int shift_zone=0; E_Int shift_wig=0; E_Int shift_coe=0; E_Int shift_mu=0; E_Int nd_current=0;
+        int64_t shift_zone=0; int64_t shift_wig=0; int64_t shift_coe=0; int64_t shift_mu=0; E_Int nd_current=0;
         E_Float rhs_end=0; E_Int ncells=0;
 
         if (param_int[0][IMPLICITSOLVER] == 1 && layer_mode >= 1) { ipt_norm_kry[ithread-1]=0.; }
-
 
         for (E_Int ntask = 0; ntask < nbtask; ntask++)
           {
@@ -291,6 +291,7 @@ if(nitcfg==1){param_real[0][TEMPS] = 0.0;}
              }
 #include "FastS/Compute/rhs.cpp"
           } 
+
 
 #ifdef Conservatif
 #include   "FastS/Compute/cp_debitIBM.cpp"

--- a/Fast/FastS/FastS/DISPLAY/display_ss_iteration.cpp
+++ b/Fast/FastS/FastS/DISPLAY/display_ss_iteration.cpp
@@ -68,7 +68,7 @@ PyObject* K_FASTS::display_ss_iteration(PyObject* self, PyObject* args)
     E_Float* cvg_zone = ipt_cvg + 4*neq*nd;
 
     //E_Float* cvg_ptr; E_Int cvg_size; E_Int cvg_nfld;
-    //K_NUMPY::getFromNumpyArray(cvg_numpy, cvg_ptr, cvg_size, cvg_nfld, true); 
+    //K_NUMPY::getFromNumpyArray(cvg_numpy, cvg_ptr, cvg_size, cvg_nfld); 
  
     //printf(" cvg_size %d %d \n",cvg_size,cvg_nfld);
 

--- a/Fast/FastS/FastS/Init/computePT_velocity_ale.cpp
+++ b/Fast/FastS/FastS/Init/computePT_velocity_ale.cpp
@@ -50,7 +50,7 @@ PyObject* K_FASTS::computePT_velocity_ale(PyObject* self, PyObject* args)
             tmp = PyDict_GetItemString(work,"MX_SSZONE");  //E_Int mx_sszone  = PyLong_AsLong(tmp);
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int shift_omp= iptdtloc[11];
   E_Int* ipt_omp = iptdtloc + shift_omp;
@@ -153,7 +153,7 @@ PyObject* K_FASTS::computePT_velocity_ale(PyObject* self, PyObject* args)
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
 
 #pragma omp parallel default(shared)

--- a/Fast/FastS/FastS/POST/computePT_enstrophy.cpp
+++ b/Fast/FastS/FastS/POST/computePT_enstrophy.cpp
@@ -44,7 +44,7 @@ PyObject* K_FASTS::computePT_enstrophy(PyObject* self, PyObject* args)
   PyObject* tmp = PyDict_GetItemString(work, "MX_SYNCHRO"); E_Int mx_synchro    = PyLong_AsLong(tmp); 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int ompmode  = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];
@@ -130,7 +130,7 @@ PyObject* K_FASTS::computePT_enstrophy(PyObject* self, PyObject* args)
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
 
   // Variables pour calcul de l enstrophie, tke

--- a/Fast/FastS/FastS/POST/computePT_gradient.cpp
+++ b/Fast/FastS/FastS/POST/computePT_gradient.cpp
@@ -49,7 +49,7 @@ PyObject* K_FASTS::computePT_gradient(PyObject* self, PyObject* args)
   PyObject* tmp = PyDict_GetItemString(work, "MX_SYNCHRO"); E_Int mx_synchro    = PyLong_AsLong(tmp); 
 
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int ompmode  = iptdtloc[8];
   E_Int shift_omp= iptdtloc[11];
@@ -168,7 +168,7 @@ PyObject* K_FASTS::computePT_gradient(PyObject* self, PyObject* args)
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
 #pragma omp parallel default(shared)
   {

--- a/Fast/FastS/FastS/POST/computePT_variables.cpp
+++ b/Fast/FastS/FastS/POST/computePT_variables.cpp
@@ -49,7 +49,7 @@ threadmax_sdm  = omp_get_max_threads();
 PyObject* tmp = PyDict_GetItemString(work, "MX_SYNCHRO"); E_Int mx_synchro    = PyLong_AsLong(tmp); 
 
 PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
 E_Int nssiter = iptdtloc[0];
 E_Int ompmode  = iptdtloc[8];
 E_Int shift_omp= iptdtloc[11];
@@ -184,7 +184,7 @@ if( flag <10000 && flag >= 1000)
 
   // Tableau de travail verrou omp
   PyObject* lokArray = PyDict_GetItemString(work,"verrou_omp"); FldArrayI* lok;
-  K_NUMPY::getFromNumpyArray(lokArray, lok, true); E_Int* ipt_lok  = lok->begin();
+  K_NUMPY::getFromNumpyArray(lokArray, lok); E_Int* ipt_lok  = lok->begin();
 
 #pragma omp parallel default(shared)
   {

--- a/Fast/FastS/FastS/STAT/computePT_my.cpp
+++ b/Fast/FastS/FastS/STAT/computePT_my.cpp
@@ -81,7 +81,7 @@ PyObject* K_FASTS::computePT_my(PyObject* self, PyObject* args)
 
   /// Tableau pour // omp
   PyObject* dtlocArray  = PyDict_GetItemString(work,"dtloc"); FldArrayI* dtloc;
-  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc, true); E_Int* iptdtloc  = dtloc->begin();
+  K_NUMPY::getFromNumpyArray(dtlocArray, dtloc); E_Int* iptdtloc  = dtloc->begin();
   E_Int nssiter = iptdtloc[0];
   E_Int omp_mode = iptdtloc[ 8 ];
   E_Int shift_omp= iptdtloc[11];

--- a/Fast/FastS/FastS/stretch.cpp
+++ b/Fast/FastS/FastS/stretch.cpp
@@ -52,7 +52,7 @@ PyObject* K_FASTS::_stretch(PyObject* self, PyObject* args)
 
  FldArrayF* coordF;
  E_Float* ipt_coordF; 
- K_NUMPY::getFromNumpyArray(coord, coordF, true); ipt_coordF = coordF->begin();
+ K_NUMPY::getFromNumpyArray(coord, coordF); ipt_coordF = coordF->begin();
 
  
  // E_Float dx2 =0.0;

--- a/Fast/FastS/FastS/testlinlets.cpp
+++ b/Fast/FastS/FastS/testlinlets.cpp
@@ -59,19 +59,19 @@ PyObject* K_FASTS::_interpfromzone(PyObject* self, PyObject* args)
 
  FldArrayF* coordDf;
  E_Float* ipt_coordDf; 
- K_NUMPY::getFromNumpyArray(coordD, coordDf, true); ipt_coordDf = coordDf->begin();
+ K_NUMPY::getFromNumpyArray(coordD, coordDf); ipt_coordDf = coordDf->begin();
 
  FldArrayF* coordRf;
  E_Float* ipt_coordRf; 
- K_NUMPY::getFromNumpyArray(coordR, coordRf, true); ipt_coordRf = coordRf->begin();
+ K_NUMPY::getFromNumpyArray(coordR, coordRf); ipt_coordRf = coordRf->begin();
 
  FldArrayF* fieldDf;
  E_Float* ipt_fieldDf; 
- K_NUMPY::getFromNumpyArray(fieldD, fieldDf, true); ipt_fieldDf = fieldDf->begin();
+ K_NUMPY::getFromNumpyArray(fieldD, fieldDf); ipt_fieldDf = fieldDf->begin();
 
  FldArrayF* fieldRf;
  E_Float* ipt_fieldRf; 
- K_NUMPY::getFromNumpyArray(fieldR, fieldRf, true); ipt_fieldRf = fieldRf->begin();
+ K_NUMPY::getFromNumpyArray(fieldR, fieldRf); ipt_fieldRf = fieldRf->begin();
 
 for (E_Int ir = 0; ir < nbptR; ++ir)
 {

--- a/Fast/FastS/test/nearmatchConservatif_t1.py
+++ b/Fast/FastS/test/nearmatchConservatif_t1.py
@@ -57,9 +57,10 @@ for base in Internal.getBases(tb):
 # t,tc=AppIBM.prepare1(tb, None, None,   vmin=15, snearsf=snearsf, frontType=frontType, cleanCellN=False,
 #                      nature=1, order=2, ext=ext, optimized=optimized, check=False)
 
-t,tc=X_IBM.prepareIBMData(tb, None, None, vmin=15, snearsf=snearsf, frontType=frontType,
-                          ext=ext+1, optimized=optimized, check=False, cleanCellN=False)
+t,tc=X_IBM.prepareIBMData(tb, None, None, vmin=15, snearsf=snearsf, frontType=frontType,verbose=3,
+                          ext=2, nature=0, extrap=0, optimized=optimized, check=False, cleanCellN=False)
 
+'''
 ####
 # The following lines are to avoid regression
 ####
@@ -111,6 +112,7 @@ for b in Internal.getBases(tc):
                 dictOfIBCRZones[rcvzoneL] = list(listOfIBCRZonesL)
             else:
                 pos += 1
+'''
 ####
 
 X_IBM._buildConservativeFlux(t, tc, verbose=1)
@@ -119,6 +121,11 @@ t1c= Internal.copyRef(tc)
 test.testT(t1c, 1)
 t1= Internal.copyRef(t)
 test.testT(t1, 2)
+'''
+'''
+
+#stop
+
 
 modulo_verif=10
 numb = {}
@@ -145,6 +152,10 @@ t1c= Internal.copyRef(tc)
 test.testT(t1c, 3)
 t1= Internal.copyRef(t)
 test.testT(t1, 4)
+'''
+'''
+
+FastC.HOOK["dtloc"][12]=2
 
 for it in range(100):
     FastS._compute(t, metrics, it, tc)


### PR DESCRIPTION
1) nettoyage argument fonction getfromNumpy 
2) shiftzone en i8
3) modif cas nearmatch_conservatif_t1.py pour tenir compte des modif du prepIBM(Optimized=-1): Fausse regression, cas a updater